### PR TITLE
Convert most containers to use common compilation container

### DIFF
--- a/components/README.dockerbuild.txt
+++ b/components/README.dockerbuild.txt
@@ -18,18 +18,28 @@ cd ${PROJ_DIR}/container-dtc-nwp/components
 
 # Build image for WPSGEOG static data
 cd wps_geog ; docker build -t dtc-nwp-wps_geog . ; cd ..
+# Instantiate data container
+docker create -v /data/WPS_GEOG --name wps_geog dtc-nwp-wps_geog
 
 # Build image for GSI input data
 cd gsi_data ; docker build -t dtc-nwp-gsi_data . ; cd ..
+# Instantiate data container
+docker create -v /data/gsi --name gsi_data dtc-nwp-gsi_data
 
 # Build image for input Sandy test case data
 cd case_data/sandy_20121027 ; docker build -t dtc-nwp-sandy . ; cd ../..
+#Instantiate data container
+docker create -v /data/sandy_20121027 --name sandy dtc-nwp-sandy
 
 # Build image for input Derecho test case data
 cd case_data/derecho_20120629 ; docker build -t dtc-nwp-derecho . ; cd ../..
+#Instantiate data container
+docker create -v /data/derecho_20120629 --name derecho dtc-nwp-derecho
 
 # Build image for input snow test case data
 cd case_data/snow_20160123 ; docker build -t dtc-nwp-snow . ; cd ../..
+# Instantiate data container
+docker create -v /data/snow_20160123 --name snow dtc-nwp-snow
 
 # Build image which compiles WPS and WRF from source
 cd wps_wrf ; docker build -t dtc-wps_wrf . ; cd ..
@@ -47,7 +57,7 @@ cd ncl ; docker build -t dtc-ncl . ; cd ..
 cd met/MET ; docker build -t dtc-met . ; cd ../..
 
 # Build images for METViewer
-cd metviewer/METViewer ; docker build -t dtc-metviewer . ; cd ../..
+cd metviewer/METviewer ; docker build -t dtc-metviewer . ; cd ../..
 
 #
 # The steps below are ONLY if you successfully completed all steps above cleanly.

--- a/components/README.dockerrun.txt
+++ b/components/README.dockerrun.txt
@@ -14,42 +14,43 @@ mkdir -p ${CASE_DIR}
 cd ${CASE_DIR}
 mkdir -p wpsprd gsiprd wrfprd postprd metprd metviewer/mysql
 
-#                                                                                                                                                             
+#
 # Run WPS script in docker-space.
 #                                                                                           
 docker run --rm -it --volumes-from wps_geog --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd \
- --name run-${CASE_NAME}-wps dtc-wps_wrf /scripts/common/run_wps.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ --name run-dtc-nwp-${CASE_NAME} dtc-wps_wrf /home/scripts/common/run_wps.ksh
 
-#                                                                                                                                                             
+#
 # Run real in docker-space.
 #                                                                                           
-
 docker run --rm -it --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-${CASE_NAME}-real dtc-wps_wrf /scripts/common/run_real.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+--name run-${CASE_NAME}-real dtc-wps_wrf /home/scripts/common/run_real.ksh
 
 #
 # Run GSI in docker-space.
 #
-docker run --rm -it --volumes-from gsi_data --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/gsiprd:/gsiprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-${CASE_NAME}-gsi dtc-gsi /scripts/common/run_gsi.ksh
+docker run --rm -it --volumes-from ${CASE_NAME} --volumes-from gsi_data \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ -v ${CASE_DIR}/gsiprd:/home/gsiprd \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ --name run-dtc-gsi-${CASE_NAME} dtc-gsi /home/scripts/common/run_gsi.ksh
 
 #
 # Run WRF in docker-space.
 #
-docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/gsiprd:/gsiprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-${CASE_NAME}-wrf dtc-wps_wrf /scripts/common/run_wrf.ksh
+docker run --rm -it --volumes-from ${CASE_NAME} \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ -v ${CASE_DIR}/gsiprd:/home/gsiprd \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ --name run-dtc-nwp-${CASE_NAME} dtc-wps_wrf /home/scripts/common/run_wrf.ksh
 
 #
 # Run UPP in docker-space.

--- a/components/README.dockerrun.txt
+++ b/components/README.dockerrun.txt
@@ -74,10 +74,10 @@ docker run --rm -it \
 # Run MET script in docker-space.
 #
 docker run -it --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/postprd:/postprd -v ${CASE_DIR}/metprd:/metprd \
- --name run-${CASE_NAME}-met dtc-met /scripts/common/run_met.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/home/scripts \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ -v ${CASE_DIR}/postprd:/home/postprd -v ${CASE_DIR}/metprd:/home/metprd \
+ --name run-${CASE_NAME}-met dtc-met /home/scripts/common/run_met.ksh
 
 #
 # Run docker compose to launch METViewer.

--- a/components/README.dockerrun.txt
+++ b/components/README.dockerrun.txt
@@ -56,10 +56,10 @@ docker run --rm -it --volumes-from ${CASE_NAME} \
 # Run UPP in docker-space.
 #
 docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/postprd:/postprd \
- --name run-${CASE_NAME}-upp dtc-upp /scripts/common/run_upp.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/postprd:/home/postprd \
+ --name run-${CASE_NAME}-upp dtc-upp /home/scripts/common/run_upp.ksh
 
 #
 # Run NCL to generate plots from WRF output.

--- a/components/README.dockerrun.txt
+++ b/components/README.dockerrun.txt
@@ -65,10 +65,10 @@ docker run --rm -it \
 # Run NCL to generate plots from WRF output.
 #
 docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/scripts/case \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/nclprd:/nclprd \
- --name run-${CASE_NAME}-ncl dtc-ncl /scripts/common/run_ncl.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}_${CASE_DATE}:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/nclprd:/home/nclprd \
+ --name run-${CASE_NAME}-ncl dtc-ncl /home/scripts/common/run_ncl.ksh
  
 #
 # Run MET script in docker-space.

--- a/components/README.dockerrun_derecho.txt
+++ b/components/README.dockerrun_derecho.txt
@@ -11,61 +11,61 @@ mkdir -p wpsprd wrfprd gsiprd postprd metprd metviewer/mysql
 #
 
 docker run --rm -it --volumes-from wps_geog --volumes-from derecho \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-derecho-wps dtc-wps_wrf /scripts/common/run_wps.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-derecho-wps dtc-wps_wrf /home/scripts/common/run_wps.ksh
 
 docker run --rm -it --volumes-from derecho \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-derecho-wps dtc-wps_wrf /scripts/common/run_real.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-derecho-wps dtc-wps_wrf /home/scripts/common/run_real.ksh
 
 #
 # Run GSI
 #
 
 docker run --rm -it --volumes-from derecho --volumes-from gsi_data \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/gsiprd:/gsiprd \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- --name run-dtc-gsi-derecho dtc-gsi /scripts/common/run_gsi.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/gsiprd:/home/gsiprd \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ --name run-dtc-gsi-derecho dtc-gsi /home/scripts/common/run_gsi.ksh
 
 #
 # Run WRF
 #
 
 docker run --rm -it --volumes-from derecho \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/wpsprd:/wpsprd \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- --name run-dtc-nwp-derecho dtc-wps_wrf /scripts/common/run_wrf.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ --name run-dtc-nwp-derecho dtc-wps_wrf /home/scripts/common/run_wrf.ksh
 
 #
 # Run UPP
 #
 
-docker run --rm -it -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
-     -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
-      -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/postprd:/postprd \
-     --name run-derecho-upp dtc-upp /scripts/common/run_upp.ksh
+docker run --rm -it -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+     -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+      -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/postprd:/home/postprd \
+     --name run-derecho-upp dtc-upp /home/scripts/common/run_upp.ksh
 
 #
 # Run NCL to generate plots from WRF output.
 #
-docker run --rm -it -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/nclprd:/nclprd \
- --name run-dtc-ncl-derecho dtc-ncl /scripts/common/run_ncl.ksh
+docker run --rm -it -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/nclprd:/home/nclprd \
+ --name run-dtc-ncl-derecho dtc-ncl /home/scripts/common/run_ncl.ksh
 
 #
 # Run MET script in docker-space.
 #
-docker run --rm -it --volumes-from derecho -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/scripts/case \
- -v ${CASE_DIR}/postprd:/postprd -v ${CASE_DIR}/metprd:/metprd \
- --name run-dtc-met-derecho dtc-met /scripts/common/run_met.ksh
+docker run --rm -it --volumes-from derecho -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/derecho_20120629:/home/scripts/case \
+ -v ${CASE_DIR}/postprd:/home/postprd -v ${CASE_DIR}/metprd:/home/metprd \
+ --name run-dtc-met-derecho dtc-met /home/scripts/common/run_met.ksh
 
 #
 # Run docker compose to launch METViewer.

--- a/components/README.dockerrun_sandy.txt
+++ b/components/README.dockerrun_sandy.txt
@@ -11,65 +11,61 @@ mkdir -p wpsprd gsiprd wrfprd postprd metprd metviewer/mysql
 #
                                                                                               
 docker run --rm -it --volumes-from wps_geog --volumes-from sandy \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd \
- --name run-sandy-wps dtc-wps_wrf /scripts/common/run_wps.ksh
-
-#                                                                                                                                                             
-# Run real in docker-space.
-#                                                                                           
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ --name run-sandy-wps dtc-wps_wrf /home/scripts/common/run_wps.ksh
 
 docker run --rm -it --volumes-from sandy \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-sandy-real dtc-wps_wrf /scripts/common/run_real.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-sandy-real dtc-wps_wrf /home/scripts/common/run_real.ksh
 
 #
 # Run GSI in docker-space.
 #
 docker run --rm -it --volumes-from gsi_data --volumes-from sandy \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/gsiprd:/gsiprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-sandy-gsi dtc-gsi /scripts/common/run_gsi.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/gsiprd:/home/gsiprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-sandy-gsi dtc-gsi /home/scripts/common/run_gsi.ksh
 
 #
 # Run WRF in docker-space.
 #
 docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/wpsprd:/wpsprd -v ${CASE_DIR}/gsiprd:/gsiprd -v ${CASE_DIR}/wrfprd:/wrfprd \
- --name run-sandy-wrf dtc-wps_wrf /scripts/common/run_wrf.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/gsiprd:/home/gsiprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-sandy-wrf dtc-wps_wrf /home/scripts/common/run_wrf.ksh
 
 #
 # Run UPP in docker-space.
 #
 docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/postprd:/postprd \
- --name run-sandy-upp dtc-upp /scripts/common/run_upp.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/postprd:/home/postprd \
+ --name run-sandy-upp dtc-upp /home/scripts/common/run_upp.ksh
 
 #
 # Run NCL to generate plots from WRF output.
 #
 docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/wrfprd:/wrfprd -v ${CASE_DIR}/nclprd:/nclprd \
- --name run-sandy-ncl dtc-ncl /scripts/common/run_ncl.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/nclprd:/home/nclprd \
+ --name run-sandy-ncl dtc-ncl /home/scripts/common/run_ncl.ksh
  
 #
 # Run MET script in docker-space.
 #
 docker run -it --volumes-from sandy \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts:/scripts \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/scripts/case \
- -v ${CASE_DIR}/postprd:/postprd -v ${CASE_DIR}/metprd:/metprd \
- --name run-sandy-met dtc-met /scripts/common/run_met.ksh
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
+ -v ${CASE_DIR}/postprd:/home/postprd -v ${CASE_DIR}/metprd:/home/metprd \
+ --name run-sandy-met dtc-met /home/scripts/common/run_met.ksh
 
 #
 # Run docker compose to launch METViewer.

--- a/components/case_data/derecho_20120629/Dockerfile
+++ b/components/case_data/derecho_20120629/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
-ENV CASE_DIR /case_data
+ENV CASE_DIR /data
 
 RUN mkdir -p ${CASE_DIR} \
  && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-derechodata_20120629.tar.gz | tar -xzC ${CASE_DIR}
 
+RUN chmod 6755 -R ${CASE_DIR}
 VOLUME $CASE_DIR
 CMD ["true"]
 

--- a/components/case_data/sandy_20121027/Dockerfile
+++ b/components/case_data/sandy_20121027/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
-ENV CASE_DIR /case_data
+ENV CASE_DIR /data/
 
 RUN mkdir -p ${CASE_DIR} \
  && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-sandydata_20121027.tar.gz | tar -xzC ${CASE_DIR}
 
+RUN chmod 6755 -R ${CASE_DIR}
 VOLUME $CASE_DIR
 CMD ["true"]
 

--- a/components/case_data/snow_20160123/Dockerfile
+++ b/components/case_data/snow_20160123/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
-ENV CASE_DIR /case_data
+ENV CASE_DIR /data
 
 RUN mkdir -p ${CASE_DIR} \
  && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-snowdata_20160123.tar.gz | tar -xzC ${CASE_DIR}
 
+RUN chmod 6755 -R ${CASE_DIR}
 VOLUME $CASE_DIR
 CMD ["true"]
 

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -1,5 +1,5 @@
-#FROM mkavulich/common-community-container:latest
-FROM cccp
+FROM mkavulich/common-community-container:latest
+#FROM mkavulich/common-community-container:gnu7
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
 # This Dockerfile compiles GSI from source during "docker build" step

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -24,41 +24,44 @@ ENV LD_LIBRARY_PATH /usr/lib:/comsoftware/libs/netcdf/lib
 ENV PATH /usr/lib64/openmpi/bin:$PATH
 ENV HDF5_ROOT $NETCDF
 #
-# Build GSI
+# Prep GSI build
 # 
 RUN pwd \ 
  && env \
  && mkdir /comsoftware/gsi/gsi_build \
  && cd /comsoftware/gsi/gsi_build \
- && sed -i 's/wij(1)/wij/g' /comsoftware/gsi/comGSIv3.7_EnKFv1.3/src/setuplight.f90 \
- && cmake /comsoftware/gsi/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION} \
- && make -j ${J}
+ && cmake /comsoftware/gsi/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION} 
+
+#
+# Fix a few GSI bugs
+#
+RUN sed -i 's/wij(1)/wij/g' /comsoftware/gsi/comGSIv3.7_EnKFv1.3/src/setuplight.f90 \
+ && sed -i 's/$/ -L\/comsoftware\/libs\/netcdf\/lib/g' /comsoftware/gsi/gsi_build/src/CMakeFiles/gsi.x.dir/link.txt \
+ && sed -i 's/$/ -L\/comsoftware\/libs\/netcdf\/lib/g' /comsoftware/gsi/gsi_build/src/enkf/CMakeFiles/enkf_wrf.x.dir/link.txt
+#
+# Build GSI
+#
+RUN cd /comsoftware/gsi/gsi_build \
+ && make -j ${J} || echo "I think your build failed yo!"
 #
 # Setup run directory
 RUN mkdir /home/gsi_run
 #
-# Set some useful settings for bashrc/cshrc
-RUN echo set -o ignoreeof >> /etc/bashrc \
- && echo set -o ignoreeof >> /etc/csh.cshrc \
-RUN set -o ignoreeof
-#
-#
 # set up ssh configuration
 #
-COPY ssh_config /root/.ssh/config
-COPY slave /gsi/slave
-RUN apt install -y openssh-client openssh-server net-tools \
-    && apt clean all \
-    && mkdir -p /var/run/sshd \
-    && ssh-keygen -A \
-    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
-    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-    && chmod 600 /root/.ssh/config \
-    && chmod 700 /root/.ssh \
-    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-    && chmod +x /gsi/slave
+#COPY ssh_config /root/.ssh/config
+#COPY slave /gsi/slave
+#RUN apt install -y openssh-client openssh-server net-tools \
+#    && apt clean all \
+#    && mkdir -p /var/run/sshd \
+#    && ssh-keygen -A \
+#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
+#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
+#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
+#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
+#    && chmod 600 /root/.ssh/config \
+#    && chmod 700 /root/.ssh \
+#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
+#    && chmod +x /gsi/slave
 #
-#RUN env
 CMD ["/home/gsiprd/run-gsi"]

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -1,5 +1,4 @@
-FROM mkavulich/common-community-container:latest
-#FROM mkavulich/common-community-container:gnu7
+FROM mkavulich/common-community-container:gnu7
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
 # This Dockerfile compiles GSI from source during "docker build" step

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -1,69 +1,47 @@
-FROM ubuntu:latest
+#FROM mkavulich/common-community-container:latest
+FROM cccp
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
 # This Dockerfile compiles GSI from source during "docker build" step
+USER comuser
+RUN mkdir /comsoftware/gsi
+WORKDIR /comsoftware/gsi
 ENV GSI_VERSION 3.7
 ENV ENKF_VERSION 1.3
 
 # Make with this many parallel tasks
 ENV J 4
 
-#SERIAL BUILD
-RUN apt update
-#RUN yum -y install file gcc gcc-gfortran gcc-c++ glibc.i686 libgcc.i686 libpng-devel jasper jasper-devel ksh hostname m4 make perl tar tcsh time wget which zlib zlib-devel epel-release
-RUN apt -y install file gcc gfortran g++ ksh hostname m4 make perl tar tcsh time wget libopenmpi-dev libnetcdf-dev libnetcdff-dev netcdf-bin libopenblas-dev cmake vim emacs nano
-#
-# now get 3rd party EPEL builds of netcdf dependencies, hdf5, openmpi stuff, cmake3, and openblas
-#RUN apt install netcdf-openmpi-devel.x86_64 netcdf-fortran-openmpi-devel.x86_64 netcdf-fortran-openmpi.x86_64 hdf5-openmpi.x86_64 openmpi.x86_64 openmpi-devel.x86_64 cmake3 openblas-devel.x86_64
-#
-
-#
-WORKDIR /gsi
-#
 # Download source code
 #
-# This command will be used after the official release
-#RUN wget https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar zxC /gsi 
-RUN wget https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv3.7_EnKFv1.3.tar.gz 
-RUN tar -xvf comGSIv3.7_EnKFv1.3.tar.gz 
-#
-#ADD comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz /gsi
-
+#RUN wget https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar zxC /comsoftware/gsi 
+RUN curl -SL https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar -xzC /comsoftware/gsi
 # Set necessary environment variables for GSI build
 #
 ENV LDFLAGS -lm
-ENV NETCDF /gsi/netcdf_links
-ENV LD_LIBRARY_PATH /usr/lib/
+ENV NETCDF /comsoftware/libs/netcdf/
+ENV LD_LIBRARY_PATH /usr/lib:/comsoftware/libs/netcdf/lib
 ENV PATH /usr/lib64/openmpi/bin:$PATH
 ENV HDF5_ROOT $NETCDF
-ENV WE_ARE_IN_THE_GSI_CONTAINER true
 #
 # Build GSI
 # 
 RUN pwd \ 
  && env \
- && mkdir netcdf_links \
- && ln -sf /usr/include /gsi/netcdf_links/ \
- && ln -sf /usr/lib/x86_64-linux-gnu/ /gsi/netcdf_links/lib \
- && mkdir gsi_build \
- && cd gsi_build \
- && cmake /gsi/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION} \
+ && mkdir /comsoftware/gsi/gsi_build \
+ && cd /comsoftware/gsi/gsi_build \
+ && sed -i 's/wij(1)/wij/g' /comsoftware/gsi/comGSIv3.7_EnKFv1.3/src/setuplight.f90 \
+ && cmake /comsoftware/gsi/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION} \
  && make -j ${J}
 #
 # Setup run directory
-RUN mkdir /gsi/gsi_run
+RUN mkdir /home/gsi_run
 #
 # Set some useful settings for bashrc/cshrc
 RUN echo set -o ignoreeof >> /etc/bashrc \
  && echo set -o ignoreeof >> /etc/csh.cshrc \
 RUN set -o ignoreeof
 #
-# copy in a couple custom scripts
-#
-#COPY docker-clean /gsi
-COPY run-gsi /gsi/gsi_run
-#RUN chmod +x /gsi/docker-clean \
-# && chmod +x /gsi/gsi_run/run-gsi
 #
 # set up ssh configuration
 #
@@ -83,4 +61,4 @@ RUN apt install -y openssh-client openssh-server net-tools \
     && chmod +x /gsi/slave
 #
 #RUN env
-CMD ["/gsi/run-gsi"]
+CMD ["/home/gsiprd/run-gsi"]

--- a/components/gsi_data/Dockerfile
+++ b/components/gsi_data/Dockerfile
@@ -1,18 +1,10 @@
-FROM ubuntu:latest
+FROM centos:latest
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
-RUN apt update
-RUN apt -y install wget
-RUN mkdir /gsi_data
+RUN mkdir -p /data/gsi
 #
-# Get GSI tutorial data
+RUN curl -SL https://dtcenter.org/com-GSI/users/downloads/GSI_releases/CRTM_v2.3.0.tar.gz | tar -xzC /data/gsi/
 #
-#RUN mkdir -p /gsi_data/ \
-# && wget  https://dtcenter.org/container_nwp_tutorial/tar_files/gsi_obs.tar -P /gsi_data/ \
-# && tar -xf /gsi_data/gsi_obs.tar -C /gsi_data/
-#
-# Download CRTM files
-RUN wget https://dtcenter.org/com-GSI/users/downloads/GSI_releases/CRTM_v2.3.0.tar.gz -P /gsi_data/ \
- && tar -xf /gsi_data/CRTM_v2.3.0.tar.gz -C /gsi_data/
-VOLUME /gsi_data
+RUN chmod 6755 -R /data/gsi
+VOLUME /data/gsi
 CMD ["true"]

--- a/components/met/MET/Dockerfile
+++ b/components/met/MET/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM mkavulich/common-community-container:gnu7
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 # 
@@ -10,149 +10,79 @@ ENV MET_RELEASE_DATE 20180927
 #
 # Compilers
 #
-ENV CC  /usr/bin/gcc
-ENV CXX /usr/bin/g++
-ENV FC  /usr/bin/gfortran
-ENV F77 /usr/bin/gfortran
+ENV CC  /opt/rh/devtoolset-7/root/usr/bin/gcc
+ENV FC  /opt/rh/devtoolset-7/root/usr/bin/gfortran
+ENV CXX /opt/rh/devtoolset-7/root/usr/bin/g++
+ENV F77 /opt/rh/devtoolset-7/root/usr/bin/gfortran
+
+RUN source /opt/rh/devtoolset-7/enable
 
 #
 # Package URL's
 #
 ENV HDF4_URL       http://www.hdfgroup.org/ftp/HDF/releases/HDF4.2r3/src/HDF4.2r3.tar.gz
-ENV HDFEOS_URL     http://www.dtcenter.org/met/users/support/online_tutorial/docker_data/HDF-EOS2.16v1.00.tar.Z
+ENV HDFEOS_URL     https://dtcenter.org/sites/default/files/community-code/met/docker_data/HDF-EOS2.16v1.00.tar.Z
 
 ENV NETCDF4C_URL   https://github.com/Unidata/netcdf-c/archive/v4.4.1.1.zip
 ENV NETCDF4CXX_URL https://github.com/Unidata/netcdf-cxx4/archive/v4.3.0.tar.gz
 
-ENV BUFRLIB_URL    http://www.dtcenter.org/met/users/support/online_tutorial/docker_data/BUFRLIB_v10-2-3.tar
-ENV GSFONT_URL     http://www.dtcenter.org/met/users/support/online_tutorial/docker_data/ghostscript-fonts-std-8.11.tar.gz
+ENV BUFRLIB_URL    https://dtcenter.org/sites/default/files/community-code/met/docker_data/BUFRLIB_v10-2-3.tar
+ENV GSFONT_URL     https://dtcenter.org/sites/default/files/community-code/met/docker_data/ghostscript-fonts-std-8.11.tar.gz
 
-ENV MET_URL        http://www.dtcenter.org/met/users/downloads/MET_releases/met-${MET_VERSION}.${MET_RELEASE_DATE}.tar.gz
-ENV PATCH_URL      http://www.dtcenter.org/met/users/support/known_issues/METv${MET_VERSION}/patches/met-${MET_VERSION}_patches_latest.tar.gz
+ENV MET_URL        https://dtcenter.org/sites/default/files/met-${MET_VERSION}.${MET_RELEASE_DATE}.tar.gz
+ENV PATCH_URL      https://dtcenter.org/sites/default/files/met-${MET_VERSION}_patches_latest.tar.gz
 
 #
 # Install required packages
 #
+USER root
 RUN yum -y update \
- && yum -y install file gcc gcc-gfortran gcc-c++ glibc.i686 libgcc.i686 \
-                   libpng-devel jasper jasper-devel zlib zlib-devel \
-                   cairo-devel freetype-devel epel-release \
-                   hostname m4 make tar tcsh ksh time wget which \
-                   flex flex-devel bison bison-devel unzip \
- && yum -y install g2clib-devel hdf5-devel.x86_64 gsl-devel \
- && yum -y install gv ncview wgrib wgrib2 ImageMagick ps2pdf \
+ && yum -y install cairo-devel freetype-devel unzip g2clib-devel gsl-devel ps2pdf \
  && yum -y install python2 python2-pip python2-devel \
  && pip install xarray numpy
 
 #
-# Set working directory
-#
-WORKDIR /met
-
-#
 # Environment for interactive bash and csh container shells
 #
-RUN echo export MET_BASE=/usr/local/share/met >> /etc/bashrc \
- && echo setenv MET_BASE /usr/local/share/met >> /etc/csh.cshrc \
- && echo export MET_FONT_DIR=/met/external_libs/fonts >> /etc/bashrc \
- && echo setenv MET_FONT_DIR /met/external_libs/fonts >> /etc/csh.cshrc \
- && echo export RSCRIPTS_BASE=/usr/local/share/met/Rscripts >> /etc/bashrc \
- && echo setenv RSCRIPTS_BASE /usr/local/share/met/Rscripts >> /etc/csh.cshrc \
- && echo export LD_LIBRARY_PATH=/usr/local/lib >> /etc/bashrc \
- && echo setenv LD_LIBRARY_PATH /usr/local/lib >> /etc/csh.cshrc
-ENV LD_LIBRARY_PATH /usr/local/lib
+ENV MET_BASE        /comsoftware/met/share/met/
+ENV MET_FONT_DIR    /comsoftware/met/external_libs/fonts
+ENV RSCRIPTS_BASE   /usr/local/share/comsoftware/met/Rscripts
+#ENV LD_LIBRARY_PATH /usr/local/lib
 
 #
-# Download BUFRLIB and GhostScript fonts
+# Download GhostScript fonts
 #
-RUN mkdir -p /met/external_libs/BUFRLIB \
- && cd /met/external_libs/BUFRLIB \
- && echo "Downloading BUFRLIB from ${BUFRLIB_URL}" \
- && curl -SL ${BUFRLIB_URL} | tar xC /met/external_libs/BUFRLIB \
- && cat preproc.sh | sed 's/cpp /cpp -traditional-cpp /g' > preproc_patch.sh \
- && chmod +x preproc_patch.sh \
- && LOG_FILE=/met/external_libs/BUFRLIB/build.log \
- && echo "Compiling BUFRLIB and writing log file ${LOG_FILE}" \
- && ./preproc_patch.sh *.F > ${LOG_FILE} \
- && ${CC} -c -DUNDERSCORE *.c >> ${LOG_FILE} \
- && ${FC} -c -fno-second-underscore *.f >> ${LOG_FILE} \
- && ar crv libbufr.a *.o >> ${LOG_FILE} \
- && rm -f /usr/lib/libbufr.a \
- && cp  *.a /usr/lib \
- && echo "Downloading GhostScript fonts from ${GSFONT_URL}" \
- && curl -SL ${GSFONT_URL} | tar zxC /met/external_libs
+USER comuser
+RUN echo "Downloading GhostScript fonts from ${GSFONT_URL}" \
+ && curl -SL ${GSFONT_URL} | tar zxC /comsoftware/libs
 
 #
-# NetCDF4 (c and c++)
-#
-RUN mkdir -p /met/external_libs \
- && cd /met/external_libs \
- && echo "Downloading netcdf-c-4.4.1.1 from ${NETCDF4C_URL}" \
- && wget ${NETCDF4C_URL} \
- && unzip v4.4.1.1.zip \
- && cd netcdf-c-4.4.1.1 \
- && LOG_FILE=/met/external_libs/netcdf-c-4.4.1.1/configure.log \
- && echo "Configuring netcdf-c-4.4.1.1 and writing log file ${LOG_FILE}" \
- && ./configure > ${LOG_FILE} \
- && LOG_FILE=/met/external_libs/netcdf-c-4.4.1.1/make_install.log \
- && echo "Compiling netcdf-c-4.4.1.1 and writing log file ${LOG_FILE}" \
- && make install > ${LOG_FILE} \
- && echo "Downloading  from ${NETCDF4CXX_URL}" \
- && cd /met/external_libs \
- && wget ${NETCDF4CXX_URL} \
- && tar -xzf v4.3.0.tar.gz \
- && cd netcdf-cxx4-4.3.0 \
- && LOG_FILE=/met/external_libs/netcdf-cxx4-4.3.0/configure.log \
- && echo "Configuring netcdf-cxx4-4.3.0 and writing log file ${LOG_FILE}" \
- && ./configure > ${LOG_FILE} \
- && LOG_FILE=/met/external_libs/netcdf-cxx4-4.3.0/make_install.log \
- && echo "Compiling netcdf-cxx4-4.3.0 and writing log file ${LOG_FILE}" \
- && make install > ${LOG_FILE}
-
-#
-# Download HDF4 and HDFEOS
-#
-RUN echo "Downloading HDF4.2r3 from ${HDF4_URL}" \
- && curl -SL ${HDF4_URL} | tar zxC /met/external_libs \
- && cd /met/external_libs/HDF4.2r3 \
- && LOG_FILE=/met/external_libs/HDF4.2r3/configure.log \
- && echo "Configuring HDF4.2r3 and writing log file ${LOG_FILE}" \
- && ./configure --prefix=/met/external_libs/HDF4.2r3 --disable-netcdf > ${LOG_FILE} \
- && cat mfhdf/hdiff/Makefile | sed 's/LIBS = -ljpeg -lz/LIBS = -ljpeg -lz -lm/g' > Makefile_NEW \
- && mv -f Makefile_NEW mfhdf/hdiff/Makefile \
- && LOG_FILE=/met/external_libs/HDF4.2r3/make_install.log \
- && echo "Compiling HDF4.2r3 and writing log file ${LOG_FILE}" \
- && make install > ${LOG_FILE} \
- && echo "Downloading hdfeos from ${HDFEOS_URL}" \
- && curl -SL ${HDFEOS_URL} | tar zxC /met/external_libs \
- && cd /met/external_libs/hdfeos \
- && LOG_FILE=/met/external_libs/hdfeos/configure.log \
- && echo "Configuring hdfeos and writing log file ${LOG_FILE}" \
- && ./configure --prefix=/met/external_libs/hdfeos --with-hdf4=/met/external_libs/HDF4.2r3 CC=/met/external_libs/HDF4.2r3/bin/h4cc > ${LOG_FILE} \
- && LOG_FILE=/met/external_libs/hdfeos/make_install.log \
- && echo "Compiling hdfeos and writing log file ${LOG_FILE}" \
- && make install > ${LOG_FILE}
-
-#
-# Download and compile MET source code and patches
+# Download and compile MET source code
 #
 RUN echo "Downloading met-${MET_VERSION} from ${MET_URL}" \
- && curl -SL ${MET_URL} | tar zxC /met \
- && echo "Downloading met-${MET_VERSION} patches from ${PATCH_URL}" \
- && curl -SL ${PATCH_URL} | tar zxC /met/met-${MET_VERSION} \
- && cd /met/met-${MET_VERSION} \
- && LOG_FILE=/met/met-${MET_VERSION}/configure.log \
+ && mkdir -p /comsoftware/met \
+ && curl -SL ${MET_URL} | tar zxC /comsoftware/met \
+# && echo "Downloading met-${MET_VERSION} patches from ${PATCH_URL}" \
+# && curl -SL ${PATCH_URL} | tar zxC /comsoftware/met/met-${MET_VERSION} \
+ && cd /comsoftware/met/met-${MET_VERSION} \
+ && LOG_FILE=/comsoftware/met/met-${MET_VERSION}/configure.log \
  && echo "Configuring met-${MET_VERSION} and writing log file ${LOG_FILE}" \
- && ./configure --enable-grib2 --enable-mode_graphics --enable-modis --enable-lidar2nc --enable-python \
-    MET_HDF=/met/external_libs/HDF4.2r3 \
-    MET_HDFEOS=/met/external_libs/hdfeos \
+ && ./configure --prefix=/comsoftware/met/ --enable-grib2 --enable-mode_graphics --enable-modis --enable-lidar2nc --enable-python \
+    MET_NETCDF=/comsoftware/libs/netcdf \
+    MET_HDF=/comsoftware/libs/HDF4.2r3 \
+    MET_HDFEOS=/comsoftware/libs/hdfeos \
     MET_FREETYPEINC=/usr/include/freetype2 MET_FREETYPELIB=/usr/lib \
     MET_CAIROINC=/usr/include/cairo MET_CAIROLIB=/usr/lib \
     MET_PYTHON_CC='-I/usr/include/python2.7' MET_PYTHON_LD='-lpython2.7' > ${LOG_FILE} \
- && LOG_FILE=/met/met-${MET_VERSION}/make_install.log \
+ && LOG_FILE=/comsoftware/met/met-${MET_VERSION}/make_install.log \
  && echo "Compiling met-${MET_VERSION} and writing log file ${LOG_FILE}" \
  && make install > ${LOG_FILE} \
- && LOG_FILE=/met/met-${MET_VERSION}/make_test.log \
+ && LOG_FILE=/comsoftware/met/met-${MET_VERSION}/make_test.log \
  && echo "Testing met-${MET_VERSION} and writing log file ${LOG_FILE}" \
  && make test > ${LOG_FILE} 2>&1
+
+#
+# Set working directory
+#
+WORKDIR /comsoftware/met
 

--- a/components/ncl/Dockerfile
+++ b/components/ncl/Dockerfile
@@ -1,7 +1,8 @@
 #
-FROM centos:latest
-MAINTAINER Kate Fossell <fossell@ucar.edu>
+FROM mkavulich/common-community-container:latest
+MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
+USER root
 RUN yum -y update
 RUN yum -y install fontconfig libgfortran libXext libXrender ImageMagick ksh
 #
@@ -9,6 +10,7 @@ RUN curl -SL https://ral.ucar.edu/sites/default/files/public/projects/ncar-docke
 #
 ENV NCARG_ROOT /usr/local
 #
-RUN mkdir /nclprd
-RUN mkdir /wrfprd
-WORKDIR /nclprd
+USER comuser
+RUN mkdir /home/nclprd
+RUN mkdir /home/wrfprd
+WORKDIR /home/nclprd

--- a/components/ncl/Dockerfile
+++ b/components/ncl/Dockerfile
@@ -1,5 +1,4 @@
-#
-FROM mkavulich/common-community-container:latest
+FROM mkavulich/common-community-container:gnu7
 MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
 USER root

--- a/components/scripts/common/met_point_verf_all.ksh
+++ b/components/scripts/common/met_point_verf_all.ksh
@@ -32,8 +32,6 @@ MKDIR=/usr/bin/mkdir
 ECHO=/usr/bin/echo
 CUT=/usr/bin/cut
 DATE=/usr/bin/date
-CALC_DATE=/scripts/common/calc_date.ksh
-RUN_CMD=/scripts/common/run_command.ksh
 
 typeset -Z2 FCST_TIME
 

--- a/components/scripts/common/met_qpf_verf_all.ksh
+++ b/components/scripts/common/met_qpf_verf_all.ksh
@@ -34,8 +34,6 @@ MKDIR=/usr/bin/mkdir
 ECHO=/usr/bin/echo
 CUT=/usr/bin/cut
 DATE=/usr/bin/date
-CALC_DATE=/scripts/common/calc_date.ksh
-RUN_CMD=/scripts/common/run_command.ksh
 
 typeset -Z2 FCST_TIME
 typeset -Z2 ACCUM_TIME

--- a/components/scripts/common/ncl/domains_png.ncl
+++ b/components/scripts/common/ncl/domains_png.ncl
@@ -16,12 +16,11 @@ begin
 ; type = "ncgm"
   type = "png"
 
-  PLTDir = "/nclprd/"
+  PLTDir = "/home/nclprd/"
   wks = gsn_open_wks(type,PLTDir+"wps_show_dom")
 
 ; read the following namelist file
-;  filename = "./namelist.wps"
-   filename = "/wpsprd/namelist.wps"
+   filename = "/home/wpsprd/namelist.wps"
 
 
 

--- a/components/scripts/common/ncl/wrf_Precip_multi_files_total_png.ncl
+++ b/components/scripts/common/ncl/wrf_Precip_multi_files_total_png.ncl
@@ -27,7 +27,7 @@ do id = 0,ndoms-1
  type = "png"
 ; type = "ps"
 ; type = "ncgm"
-  wks = gsn_open_wks(type,PLTDir + "plt_Precip_multi_total_"+domains(id)+"_")
+  wks = gsn_open_wks(type,PLTDir + "plt_Precip_multi_total_"+domains(id))
 
 
 ; Set some basic resources

--- a/components/scripts/common/ncl/wrf_Precip_multi_files_total_png.ncl
+++ b/components/scripts/common/ncl/wrf_Precip_multi_files_total_png.ncl
@@ -8,8 +8,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/wrf/WRFUserARW.ncl"
 begin
 ;
 ; Make a list of all files we are interested in
-  DATADir = "/wrfprd/"
-  PLTDir = "/nclprd/"
+  DATADir = "/home/wrfprd/"
+  PLTDir = "/home/nclprd/"
   domains = str_split(getenv("domain_list"), " ")
   ndoms   = dimsizes(domains)
 

--- a/components/scripts/common/ncl/wrf_Reflectivity_files_png.ncl
+++ b/components/scripts/common/ncl/wrf_Reflectivity_files_png.ncl
@@ -28,7 +28,7 @@ do id = 0,ndoms-1
 ; type = "ps"
  type = "png"
 ; type = "ncgm"
-  wks = gsn_open_wks(type,PLTDir+"plt_dbz1"+domains(id)+"_")
+  wks = gsn_open_wks(type,PLTDir+"plt_dbz1"+domains(id))
   gsn_define_colormap(wks,"WhViBlGrYeOrReWh")       ; Overwrite the standard color map
 
 ; Set some basic resources

--- a/components/scripts/common/ncl/wrf_Reflectivity_files_png.ncl
+++ b/components/scripts/common/ncl/wrf_Reflectivity_files_png.ncl
@@ -9,8 +9,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/wrf/WRFUserARW.ncl"
 begin
 ;
 ; Make a list of all files we are interested in
-  DATADir = "/wrfprd/"
-  PLTDir = "/nclprd/"
+  DATADir = "/home/wrfprd/"
+  PLTDir = "/home/nclprd/"
   domains = str_split(getenv("domain_list"), " ")
   ndoms   = dimsizes(domains)  
 

--- a/components/scripts/common/ncl/wrf_Surface_files_png.ncl
+++ b/components/scripts/common/ncl/wrf_Surface_files_png.ncl
@@ -9,8 +9,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/wrf/WRFUserARW.ncl"
 begin
 ;
 ; Make a list of all files we are interested in
-  DATADir = "/wrfprd/"
-  PLTDir = "/nclprd/"
+  DATADir = "/home/wrfprd/"
+  PLTDir = "/home/nclprd/"
   domains = str_split(getenv("domain_list"), " ")
   ndoms   = dimsizes(domains)
 

--- a/components/scripts/common/ncl/wrf_Surface_files_png.ncl
+++ b/components/scripts/common/ncl/wrf_Surface_files_png.ncl
@@ -33,7 +33,7 @@ do id = 0,ndoms-1
 ; type = "ps"
  type = "png"
 ; type = "ncgm"
-  wks = gsn_open_wks(type,PLTDir + "plt_Surface_multi_"+domains(id)+"_")
+  wks = gsn_open_wks(type,PLTDir + "plt_Surface_multi_"+domains(id))
 
 ; Set some basic resources
   res = True

--- a/components/scripts/common/run_gsi.ksh
+++ b/components/scripts/common/run_gsi.ksh
@@ -54,7 +54,7 @@ set -x
  # using tm06 NDAS prepbufr here, so need have proper date for the observation file, which is ANAL_TIME + 6 hour
   OBSTIME=`${GSI_BUILD}/bin/ndate.x +6 ${ANAL_TIME} `
   HHH=`echo $OBSTIME | cut -c9-10`
-  PREPBUFR=${PREPBUFR:-/case_data/obs_data/prepbufr/$OBSTIME/ndas.t${HHH}z.prepbufr.tm06.nr}
+  PREPBUFR=${PREPBUFR:-/data/obs_data/prepbufr/$OBSTIME/ndas.t${HHH}z.prepbufr.tm06.nr}
 #
 #------------------------------------------------
 # bk_core= which WRF core is used as background (NMM or ARW or NMMB)

--- a/components/scripts/common/run_gsi.ksh
+++ b/components/scripts/common/run_gsi.ksh
@@ -16,10 +16,10 @@ set -x
             # DARWIN_PGI
 #
 # Constants
-  INPUT_DIR="/case_data"
-  SCRIPT_DIR="/scripts/common"
-  CASE_DIR="/scripts/case"
-  WRFPRD_DIR="/wrfprd"
+  INPUT_DIR="/data/gsi"
+  SCRIPT_DIR="/home/scripts/common"
+  CASE_DIR="/home/scripts/case"
+  WRFPRD_DIR="/home/wrfprd"
 
 # Include case-specific settings
 . $CASE_DIR/set_env.ksh
@@ -45,9 +45,9 @@ set -x
   DD=`ncdump -h ${BK_FILE} | grep ":START_DATE" | cut -f2 -d"=" | cut -c11-12`
   HH=`ncdump -h ${BK_FILE} | grep ":START_DATE" | cut -f2 -d"=" | cut -c14-15`
   ANAL_TIME=${YYYY}${MM}${DD}${HH}
-  CRTM_ROOT=/gsi_data/CRTM_v2.3.0
-  GSI_ROOT=/gsi/comGSIv3.7_EnKFv1.3
-  GSI_BUILD=/gsi/gsi_build
+  CRTM_ROOT=/data/gsi/CRTM_v2.3.0
+  GSI_ROOT=/comsoftware/gsi/comGSIv3.7_EnKFv1.3
+  GSI_BUILD=/comsoftware/gsi/gsi_build
   FIX_ROOT=${GSI_ROOT}/fix/
   GSI_EXE=${GSI_BUILD}/bin/gsi.x
   GSI_NAMELIST=${GSI_ROOT}/ush/comgsi_namelist.sh

--- a/components/scripts/common/run_gsi.ksh
+++ b/components/scripts/common/run_gsi.ksh
@@ -37,7 +37,7 @@ set -x
 # GSI_EXE  = path and name of the gsi executable 
 # ENS_ROOT = path where ensemble background files exist
 
-  WORK_ROOT=/gsiprd
+  WORK_ROOT=/home/gsiprd
   BK_ROOT=${WRFPRD_DIR}
   BK_FILE=${BK_ROOT}/wrfinput_d01
   YYYY=`ncdump -h ${BK_FILE} | grep ":START_DATE" | cut -f2 -d"=" | cut -c3-6`

--- a/components/scripts/common/run_met.ksh
+++ b/components/scripts/common/run_met.ksh
@@ -5,12 +5,13 @@
 #
 
 # Constants
-MET_BUILD="/met"
-SCRIPT_DIR="/scripts/common"
-CASE_DIR="/scripts/case"
-POSTPRD_DIR="/postprd"
-METPRD_DIR="/metprd"
+MET_BUILD="/comsoftware/met"
+SCRIPT_DIR="/home/scripts/common"
+CASE_DIR="/home/scripts/case"
+POSTPRD_DIR="/home/postprd"
+METPRD_DIR="/home/metprd"
 LOG_FILE="${METPRD_DIR}/run_met.log"
+OBS_BASE_DIR="/data/obs_data"
 
 # Check for the correct container
 if [[ ! -e $MET_BUILD ]]; then
@@ -46,9 +47,11 @@ fi
 echo "Running MET and writing log file: ${LOG_FILE}" | tee $LOG_FILE
 
 # Constants for all cases
-export MET_EXE_ROOT=/usr/local/bin
-export MET_CONFIG=/scripts/case/met_config
-export DATAROOT=/
+export MET_EXE_ROOT=${MET_BUILD}/bin
+export MET_CONFIG=/home/scripts/case/met_config
+export DATAROOT=/home/
+export CALC_DATE=${SCRIPT_DIR}/calc_date.ksh
+export RUN_CMD=${SCRIPT_DIR}/run_command.ksh
 
 cp $SCRIPT_DIR/met_qpf_verf_all.ksh .
 cp $SCRIPT_DIR/met_point_verf_all.ksh .
@@ -66,7 +69,7 @@ while [ $FCST_TIME -le $FCST_HR_END ] ; do
   export FCST_TIME
 
   # Do point verification
-  export RAW_OBS=/case_data/obs_data/prepbufr
+  export RAW_OBS=${OBS_BASE_DIR}/prepbufr
   ./met_point_verf_all.ksh | tee -a $LOG_FILE
 
   # Do qpf verification
@@ -75,7 +78,7 @@ while [ $FCST_TIME -le $FCST_HR_END ] ; do
     echo "BUCKET_TIME = $BUCKET_TIME" | tee -a $LOG_FILE
     export ACCUM_TIME
     export BUCKET_TIME
-    export RAW_OBS=/case_data/obs_data/qpe
+    export RAW_OBS=${OBS_BASE_DIR}/qpe
     ./met_qpf_verf_all.ksh | tee -a $LOG_FILE
   fi
 

--- a/components/scripts/common/run_ncl.ksh
+++ b/components/scripts/common/run_ncl.ksh
@@ -6,10 +6,10 @@
 
 # Constants
 NCL_BIN="/usr/local/bin/ncl"
-SCRIPT_DIR="/scripts/common"
-CASE_DIR="/scripts/case"
-WRFPRD_DIR="/wrfprd"
-NCLPRD_DIR="/nclprd"
+SCRIPT_DIR="/home/scripts/common"
+CASE_DIR="/home/scripts/case"
+WRFPRD_DIR="/home/wrfprd"
+NCLPRD_DIR="/home/nclprd"
 
 # Check for the correct container
 if [[ ! -e $NCL_BIN ]]; then

--- a/components/scripts/common/run_real.ksh
+++ b/components/scripts/common/run_real.ksh
@@ -1,16 +1,16 @@
 #!/bin/ksh
-  
+set -x  
 #
 # Simplified script to run WRF real in Docker world
 #
 
 # Constants
-WRF_BUILD="/wrf"
-INPUT_DIR="/case_data"
-SCRIPT_DIR="/scripts/common"
-CASE_DIR="/scripts/case"
-WPSPRD_DIR="/wpsprd"
-WRFPRD_DIR="/wrfprd"
+WRF_BUILD="/comsoftware/wrf"
+INPUT_DIR="/data"
+SCRIPT_DIR="/home/scripts/common"
+CASE_DIR="/home/scripts/case"
+WPSPRD_DIR="/home/wpsprd"
+WRFPRD_DIR="/home/wrfprd"
 
 # Check for the correct container
 if [[ ! -e $WRF_BUILD ]]; then

--- a/components/scripts/common/run_upp.ksh
+++ b/components/scripts/common/run_upp.ksh
@@ -22,7 +22,7 @@ set -x
 #--------------------------------------------------------
 
 # Include case-specific settings
-. /scripts/case/set_env.ksh
+. /home/scripts/case/set_env.ksh
 
 #----------------------------------------------------------------------------------
 #--- USER EDIT DESCIPTIONS --------------------------------------------------------
@@ -79,15 +79,15 @@ set -x
 # This script assumes you created a directory $DOMAINPATH/postprd
 # and that your model output is in $DOMAINPATH/wrfprd or $DOMAINPATH/nemsprd
 # as recommended in the users guide where UPP will output.
-export TOP_DIR=/
+export TOP_DIR=/home/
 export DOMAINPATH=${TOP_DIR}
-export UNIPOST_HOME=/upp/UPPV4.0
+export UNIPOST_HOME=/comsoftware/upp/UPPV4.0
 export POSTEXEC=${UNIPOST_HOME}/bin
 export SCRIPTS=${UNIPOST_HOME}/scripts
-export modelDataPath=/wrfprd            # or nemsprd
-export paramFile=/scripts/case/wrf_cntrl.parm   # or nmb_cntrl.parm
-export xmlCntrlFile=/scripts/case/postcntrl.xml # for grib2
-export txtCntrlFile=/scripts/case/postxconfig-NT_WRF.txt # grib2
+export modelDataPath=/home/wrfprd            # or nemsprd
+export paramFile=/home/scripts/case/wrf_cntrl.parm   # or nmb_cntrl.parm
+export xmlCntrlFile=/home/scripts/case/postcntrl.xml # for grib2
+export txtCntrlFile=/home/scripts/case/postxconfig-NT_WRF.txt # grib2
 
 # Specify Dyn Core (ARW or NMM or NMB in upper case)
 export dyncore="ARW"

--- a/components/scripts/common/run_wps.ksh
+++ b/components/scripts/common/run_wps.ksh
@@ -1,15 +1,15 @@
 #!/bin/ksh
-
+set -x
 #
 # Simplified script to run WPS in Docker world
 #
 
 # Constants
-WRF_BUILD="/wrf"
-INPUT_DIR="/case_data"
-SCRIPT_DIR="/scripts/common"
-CASE_DIR="/scripts/case"
-WPSPRD_DIR="/wpsprd"
+WRF_BUILD="/comsoftware/wrf"
+INPUT_DIR="/data/"
+SCRIPT_DIR="/home/scripts/common"
+CASE_DIR="/home/scripts/case"
+WPSPRD_DIR="/home/wpsprd"
 
 # Check for the correct container
 if [[ ! -e $WRF_BUILD ]]; then

--- a/components/scripts/common/run_wrf.ksh
+++ b/components/scripts/common/run_wrf.ksh
@@ -6,12 +6,12 @@
 #
 
 # Constants
-WRF_BUILD="/wrf"
-INPUT_DIR="/case_data"
-SCRIPT_DIR="/scripts/common"
-CASE_DIR="/scripts/case"
-WRFPRD_DIR="/wrfprd"
-GSIPRD_DIR="/gsiprd"
+WRF_BUILD="/comsoftware/wrf"
+INPUT_DIR="/data/case_data"
+SCRIPT_DIR="/home/scripts/common"
+CASE_DIR="/home/scripts/case"
+WRFPRD_DIR="/home/wrfprd"
+GSIPRD_DIR="/home/gsiprd"
 
 # Check for the correct container
 if [[ ! -e $WRF_BUILD ]]; then

--- a/components/scripts/derecho_20120629/namelist.input
+++ b/components/scripts/derecho_20120629/namelist.input
@@ -25,7 +25,7 @@
  io_form_input                       = 2,
  io_form_boundary                    = 2,
  debug_level                         = 0,
- history_outname  = "/wrfprd/wrfout_d<domain>_<date>.nc"
+ history_outname  = "wrfout_d<domain>_<date>.nc"
  nocolons                            = .true.
  /
 

--- a/components/scripts/derecho_20120629/namelist.wps
+++ b/components/scripts/derecho_20120629/namelist.wps
@@ -23,8 +23,8 @@
  truelat1  =  39.60,
  truelat2  =  40.60,
  stand_lon = -84.90,
- geog_data_path = '/WPS_GEOG/',
- opt_geogrid_tbl_path = '/wrf/WPS-4.1/geogrid',
+ geog_data_path = '/data/WPS_GEOG/',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
 /
 
 &ungrib
@@ -35,6 +35,6 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/wrf/WPS-4.1/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
 /
 

--- a/components/scripts/derecho_20120629/namelist.wps
+++ b/components/scripts/derecho_20120629/namelist.wps
@@ -24,7 +24,7 @@
  truelat2  =  40.60,
  stand_lon = -84.90,
  geog_data_path = '/WPS_GEOG/',
- opt_geogrid_tbl_path = '/wrf/WPS-4.0.2/geogrid',
+ opt_geogrid_tbl_path = '/wrf/WPS-4.1/geogrid',
 /
 
 &ungrib
@@ -35,6 +35,6 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/wrf/WPS-4.0.2/metgrid',
+ opt_metgrid_tbl_path = '/wrf/WPS-4.1/metgrid',
 /
 

--- a/components/scripts/derecho_20120629/set_env.ksh
+++ b/components/scripts/derecho_20120629/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.0.2"
-export WRF_VERSION="4.0.2"
+export WPS_VERSION="4.1"
+export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/derecho_20120629/set_env.ksh
+++ b/components/scripts/derecho_20120629/set_env.ksh
@@ -7,8 +7,8 @@ export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################
-export OBS_ROOT=/case_data/obs_data/prepbufr/
-export PREPBUFR=/case_data/obs_data/prepbufr/2012063000/ndas.t00z.prepbufr.tm12.nr
+export OBS_ROOT=/data/obs_data/prepbufr/
+export PREPBUFR=/data/obs_data/prepbufr/2012063000/ndas.t00z.prepbufr.tm12.nr
 
 # UPP settings
 ########################################################################

--- a/components/scripts/sandy_20121027/namelist.input
+++ b/components/scripts/sandy_20121027/namelist.input
@@ -26,7 +26,7 @@
  io_form_input                       = 2
  io_form_boundary                    = 2
  debug_level                         = 0
- history_outname  = "/wrfprd/wrfout_d<domain>_<date>.nc"
+ history_outname  = "wrfout_d<domain>_<date>.nc"
  nocolons                            = .true.
  /
 

--- a/components/scripts/sandy_20121027/namelist.wps
+++ b/components/scripts/sandy_20121027/namelist.wps
@@ -24,7 +24,7 @@
  truelat2  =  60.0,
  stand_lon = -73.0,
  geog_data_path = '/WPS_GEOG/',
- opt_geogrid_tbl_path = '/wrf/WPS-4.0.2/geogrid',
+ opt_geogrid_tbl_path = '/wrf/WPS-4.1/geogrid',
 /
 
 &ungrib
@@ -35,5 +35,5 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/wrf/WPS-4.0.2/metgrid',
+ opt_metgrid_tbl_path = '/wrf/WPS-4.1/metgrid',
 /

--- a/components/scripts/sandy_20121027/namelist.wps
+++ b/components/scripts/sandy_20121027/namelist.wps
@@ -23,8 +23,8 @@
  truelat1  =  30.0,
  truelat2  =  60.0,
  stand_lon = -73.0,
- geog_data_path = '/WPS_GEOG/',
- opt_geogrid_tbl_path = '/wrf/WPS-4.1/geogrid',
+ geog_data_path = '/data/WPS_GEOG/',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
 /
 
 &ungrib
@@ -35,5 +35,5 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/wrf/WPS-4.1/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
 /

--- a/components/scripts/sandy_20121027/set_env.ksh
+++ b/components/scripts/sandy_20121027/set_env.ksh
@@ -7,8 +7,8 @@ export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################
-export OBS_ROOT=/case_data/obs_data/prepbufr/
-export PREPBUFR=/case_data/obs_data/prepbufr/2012102718/ndas.t18z.prepbufr.tm06.nr
+export OBS_ROOT=/data/obs_data/prepbufr/
+export PREPBUFR=/data/obs_data/prepbufr/2012102718/ndas.t18z.prepbufr.tm06.nr
 
 # UPP settings
 ########################################################################

--- a/components/scripts/sandy_20121027/set_env.ksh
+++ b/components/scripts/sandy_20121027/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.0.2"
-export WRF_VERSION="4.0.2"
+export WPS_VERSION="4.1"
+export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/snow_20160123/namelist.input
+++ b/components/scripts/snow_20160123/namelist.input
@@ -26,7 +26,7 @@
  io_form_input                       = 2
  io_form_boundary                    = 2
  debug_level                         = 0
- history_outname  = "/wrfprd/wrfout_d<domain>_<date>.nc"
+ history_outname  = "wrfout_d<domain>_<date>.nc"
  nocolons                            = .true.
  /
 

--- a/components/scripts/snow_20160123/namelist.wps
+++ b/components/scripts/snow_20160123/namelist.wps
@@ -23,8 +23,8 @@
  truelat1  =  38.0,
  truelat2  =  39.0,
  stand_lon = -97.0,
- geog_data_path = '/WPS_GEOG/',
- opt_geogrid_tbl_path = '/wrf/WPS-4.0.2/geogrid',
+ geog_data_path = '/data/WPS_GEOG/',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
 /
 
 &ungrib
@@ -35,5 +35,5 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/wrf/WPS-4.0.2/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
 /

--- a/components/scripts/snow_20160123/set_env.ksh
+++ b/components/scripts/snow_20160123/set_env.ksh
@@ -7,7 +7,7 @@ export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################
-export OBS_ROOT=/case_data/obs_data/prepbufr/2016012300/
+export OBS_ROOT=/data/obs_data/prepbufr/2016012300/
 
 # UPP settings
 ########################################################################

--- a/components/scripts/snow_20160123/set_env.ksh
+++ b/components/scripts/snow_20160123/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.0.2"
-export WRF_VERSION="4.0.2"
+export WPS_VERSION="4.1"
+export WRF_VERSION="4.1.1"
 
 # GSI settings
 ########################################################################

--- a/components/upp/Dockerfile
+++ b/components/upp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:latest
+FROM mkavulich/common-community-container:gnu7
 MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
 # This Dockerfile compiles UPP from source during "docker build" step

--- a/components/upp/Dockerfile
+++ b/components/upp/Dockerfile
@@ -1,53 +1,51 @@
-FROM centos:latest
-MAINTAINER Kate Fossell <fossell@ucar.edu>
+FROM mkavulich/common-community-container:latest
+MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
 # This Dockerfile compiles UPP from source during "docker build" step
+USER comuser
+RUN mkdir /comsoftware/upp
+WORKDIR /comsoftware/upp
 ENV UPP_VERSION 4.0
  
 #SERIAL BUILD
-RUN yum -y update
-RUN yum -y install file gcc gcc-gfortran gcc-c++ glibc.i686 libgcc.i686 libpng-devel jasper jasper-devel ksh hostname m4 make perl tar tcsh time wget which zlib zlib-devel epel-release
+#RUN yum -y update
+#RUN yum -y install file gcc gcc-gfortran gcc-c++ glibc.i686 libgcc.i686 libpng-devel jasper jasper-devel ksh hostname m4 make perl tar tcsh time wget which zlib zlib-devel epel-release
 #
 # now get 3rd party EPEL builds of netcdf dependencies
-RUN yum -y install netcdf-devel.x86_64 netcdf-fortran-devel.x86_64 netcdf-fortran.x86_64 hdf5.x86_64
+#RUN yum -y install netcdf-devel.x86_64 netcdf-fortran-devel.x86_64 netcdf-fortran.x86_64 hdf5.x86_64
 #
 # now get 3rd party EPEL builds of netcdf and openmpi dependencies
-RUN yum -y install netcdf-openmpi-devel.x86_64 netcdf-fortran-openmpi-devel.x86_64 netcdf-fortran-openmpi.x86_64 hdf5-openmpi.x86_64 openmpi.x86_64 openmpi-devel.x86_64
+#RUN yum -y install netcdf-openmpi-devel.x86_64 netcdf-fortran-openmpi-devel.x86_64 netcdf-fortran-openmpi.x86_64 hdf5-openmpi.x86_64 openmpi.x86_64 openmpi-devel.x86_64
 #
-WORKDIR /upp
-#
-# Download original sources
-#
-#RUN curl -SL http://www.dtcenter.org/upp/users/downloads/UPP_releases/DTC_upp_v${UPP_VERSION}.tar.gz | tar zxC /upp
-RUN curl -SL https://dtcenter.org/sites/default/files/code/DTC_upp_v${UPP_VERSION}.tar.gz | tar zxC /upp
-
-#
+# Download original source
+RUN curl -SL https://dtcenter.org/sites/default/files/code/DTC_upp_v${UPP_VERSION}.tar.gz | tar zxC /comsoftware/upp
 
 # Set environment for interactive container shells
 #
-RUN echo export LDFLAGS="-lm" >> /etc/bashrc \ 
- && echo export NETCDF=/upp/netcdf_links >> /etc/bashrc \
- && echo export JASPERINC=/usr/include/jasper/ >> /etc/bashrc \
- && echo export JASPERLIB=/usr/lib64/ >> /etc/bashrc \
- && echo export LD_LIBRARY_PATH="/usr/lib64" >> /etc/bashrc \
- && echo export PATH="/usr/lib64/bin:$PATH" >> /etc/bashrc \
- && echo setenv LDFLAGS "-lm" >> /etc/csh.cshrc \
- && echo setenv NETCDF "/upp/netcdf_links" >> /etc/csh.cshrc \
- && echo setenv JASPERINC "/usr/include/jasper/" >> /etc/csh.cshrc \
- && echo setenv JASPERLIB "/usr/lib64/" >> /etc/csh.cshrc \
- && echo setenv LD_LIBRARY_PATH "/usr/lib64" >> /etc/csh.cshrc \
- && echo setenv PATH "/usr/lib64/bin:$PATH" >> /etc/csh.cshrc
+RUN echo export LDFLAGS="-lm" >> /home/.bashrc \ 
+ && echo export NETCDF=/comsoftware/libs/netcdf/ >> /home/.bashrc \
+ && echo export PATH="/usr/lib64/openmpi/bin:$PATH" >> /home/.bashrc \
+ && echo export JASPERINC=/usr/include/jasper/ >> /home/.bashrc \
+ && echo export JASPERLIB=/usr/lib64/ >> /home/.bashrc \
+ && echo export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib" >> /home/.bashrc \
+ && echo export PATH="/usr/lib64/openmpi/bin:$PATH" >> /home/.bashrc \
+# && echo export LD_LIBRARY_PATH="/usr/lib64" >> /etc/bashrc \
+# && echo export PATH="/usr/lib64/bin:$PATH" >> /etc/bashrc \
+ && echo setenv LDFLAGS "-lm" >> /home/.cshrc \
+ && echo setenv NETCDF /comsoftware/libs/netcdf/ >> /home/.cshrc \
+ && echo setenv JASPERINC "/usr/include/jasper/" >> /home/.cshrc \
+ && echo setenv JASPERLIB "/usr/lib64/" >> /home/.cshrc \
+ && echo setenv LD_LIBRARY_PATH "/usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib" >> /home/.cshrc \
+ && echo setenv PATH "/usr/lib64/openmpi/bin:$PATH" >> /home/.cshrc
+# && echo setenv LD_LIBRARY_PATH "/usr/lib64" >> /home/.cshrc \
+# && echo setenv PATH "/usr/lib64/bin:$PATH" >> /home/.cshrc
 #
 #
 # Build UPP 
 # input 7 to configure script (for gfortran serial build)
 
 RUN pwd \
- && mkdir netcdf_links \
- && ln -sf /usr/include/ netcdf_links/include \
- && ln -sf /usr/lib64 netcdf_links/lib \
- && ln -sf /usr/lib64/gfortran/modules/netcdf.mod netcdf_links/include \
- && export NETCDF=/upp/netcdf_links \
+ && export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
  && cd ./UPPV${UPP_VERSION} \
@@ -55,29 +53,32 @@ RUN pwd \
  && /bin/csh ./compile > compile_upp.log 2>&1
 #
 #
-ENV LD_LIBRARY_PATH /usr/lib64/lib
-ENV PATH  /usr/lib64/bin:$PATH
+ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
+ENV PATH /usr/lib64/openmpi/bin:$PATH
 #
-# copy in a couple custom scripts
+# copy in a custom script...apparently there's no way to docker COPY with non-root permissions....
 #
-COPY run-upp /upp
-RUN chmod +x /upp/run-upp
+USER root
+COPY run-upp /comsoftware/upp
+RUN chmod +x /comsoftware/upp/run-upp \
+ && chown comuser:comusers /comsoftware/upp/run-upp
+USER comuser
 #
 # set up ssh configuration
 #
-COPY ssh_config /root/.ssh/config
-COPY slave /upp/slave
-RUN yum install -y openssh-clients openssh-server net-tools \
-    && yum clean all \
-    && mkdir -p /var/run/sshd \
-    && ssh-keygen -A \
-    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
-    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-    && chmod 600 /root/.ssh/config \
-    && chmod 700 /root/.ssh \
-    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-    && chmod +x /upp/slave
+#COPY ssh_config /root/.ssh/config
+#COPY slave /upp/slave
+#RUN yum install -y openssh-clients openssh-server net-tools \
+#    && yum clean all \
+#    && mkdir -p /var/run/sshd \
+#    && ssh-keygen -A \
+#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
+#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
+#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
+#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
+#    && chmod 600 /root/.ssh/config \
+#    && chmod 700 /root/.ssh \
+#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
+#    && chmod +x /upp/slave
 
 CMD ["/upp/run-upp"]

--- a/components/wps_geog/Dockerfile
+++ b/components/wps_geog/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 #
-RUN mkdir /WPS_GEOG
+RUN mkdir -p /data/WPS_GEOG
 #
-RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/geog_minimum.tar.gz | tar -xzC /WPS_GEOG
+RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/geog_minimum.tar.gz | tar -xzC /data/WPS_GEOG
 #
-VOLUME /WPS_GEOG
+RUN chmod 6755 -R /data/WPS_GEOG
+VOLUME /data/WPS_GEOG
 CMD ["true"]

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -32,6 +32,7 @@ RUN pwd \
  && cd ./WRF-${WRF_VERSION} \
  && ./configure <<< $'34\r1\r' \
  && sed -i -e '/^DM_CC/ s/$/ -DMPI2_SUPPORT/' ./configure.wrf \
+ && sed -i '/BUILD_RRTMG_FAST/d' ./configure.wrf \
  && /bin/csh ./compile em_real > compile_wrf_arw_opt34.1.log 2>&1
 # Check build success
 RUN ls WRF-${WRF_VERSION}/main/real.exe WRF-${WRF_VERSION}/main/wrf.exe

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:latest
+FROM mkavulich/common-community-container:gnu7
 MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 # 
 # This Dockerfile compiles WRF from source during "docker build" step
@@ -29,6 +29,7 @@ RUN pwd \
  && export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
+ && export J='-j 4' \
  && cd ./WRF-${WRF_VERSION} \
  && ./configure <<< $'34\r1\r' \
  && sed -i -e '/^DM_CC/ s/$/ -DMPI2_SUPPORT/' ./configure.wrf \

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 USER comuser
 RUN mkdir /comsoftware/wrf
 WORKDIR /comsoftware/wrf
-ENV WRF_VERSION 4.0.2
-ENV WPS_VERSION 4.0.2
+ENV WRF_VERSION 4.1.1
+ENV WPS_VERSION 4.1
 #
 # Download original sources
 #
@@ -16,10 +16,10 @@ RUN curl -SL https://github.com/wrf-model/WRF/archive/v${WRF_VERSION}.tar.gz | t
 # Set environment for interactive container shells
 #
 RUN echo export LDFLAGS="-lm" >> /home/.bashrc \
- && echo export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib" >> /home/.bashrc \
+ && echo export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib" >> /home/.bashrc \
  && echo export PATH="/usr/lib64/openmpi/bin:$PATH" >> /home/.bashrc \
  && echo setenv LDFLAGS "-lm" >> /home/.cshrc \
- && echo setenv LD_LIBRARY_PATH "/usr/lib64/openmpi/lib" >> /home/.cshrc \
+ && echo setenv LD_LIBRARY_PATH "/usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib" >> /home/.cshrc \
  && echo setenv PATH "/usr/lib64/openmpi/bin:$PATH" >> /home/.cshrc
 #
 # Build WRF first
@@ -33,19 +33,24 @@ RUN pwd \
  && ./configure <<< $'34\r1\r' \
  && sed -i -e '/^DM_CC/ s/$/ -DMPI2_SUPPORT/' ./configure.wrf \
  && /bin/csh ./compile em_real > compile_wrf_arw_opt34.1.log 2>&1
+# Check build success
+RUN ls WRF-${WRF_VERSION}/main/real.exe WRF-${WRF_VERSION}/main/wrf.exe
 #
 # Build WPS second
 #
 # input 1 to configure script (gfortran serial build)
-RUN cd ./WPS-${WPS_VERSION} \
+RUN ln -sf WRF-${WRF_VERSION} WRF \
+ && cd ./WPS-${WPS_VERSION} \
  && echo export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
  && ./configure <<< $'1\r' \
  && sed -i -e 's/-L$(NETCDF)\/lib/-L$(NETCDF)\/lib -lnetcdff /' ./configure.wps \
  && /bin/csh ./compile > compile_wps.log 2>&1
+# Check build success
+RUN ls WPS-${WPS_VERSION}/metgrid.exe WPS-${WPS_VERSION}/ungrib.exe WPS-${WPS_VERSION}/geogrid.exe
 #
-ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib
+ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
 ENV PATH  /usr/lib64/openmpi/bin:$PATH
 #
 # copy in a couple custom scripts...apparently there's no way to docker COPY with non-root permissions....

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -1,49 +1,32 @@
-FROM centos:latest
+FROM mkavulich/common-community-container:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 # 
 # This Dockerfile compiles WRF from source during "docker build" step
+USER comuser
+RUN mkdir /comsoftware/wrf
+WORKDIR /comsoftware/wrf
 ENV WRF_VERSION 4.0.2
 ENV WPS_VERSION 4.0.2
- 
-RUN yum -y update
-RUN yum -y install file gcc gcc-gfortran gcc-c++ glibc.i686 libgcc.i686 libpng-devel jasper jasper-devel ksh hostname m4 make perl tar tcsh time wget which zlib zlib-devel epel-release
-#
-# now get 3rd party EPEL builds of netcdf dependencies
-RUN yum -y install netcdf-devel.x86_64 netcdf-fortran-devel.x86_64 netcdf-fortran.x86_64 hdf5.x86_64
-#
-# now get 3rd party EPEL builds of netcdf and openmpi dependencies
-RUN yum -y install netcdf-openmpi-devel.x86_64 netcdf-fortran-openmpi-devel.x86_64 netcdf-fortran-openmpi.x86_64 hdf5-openmpi.x86_64 openmpi.x86_64 openmpi-devel.x86_64
-#
-WORKDIR /wrf
 #
 # Download original sources
 #
-RUN curl -SL https://github.com/wrf-model/WRF/archive/v${WRF_VERSION}.tar.gz | tar zxC /wrf \
- && curl -SL https://github.com/wrf-model/WPS/archive/v${WPS_VERSION}.tar.gz | tar zxC /wrf
+RUN curl -SL https://github.com/wrf-model/WRF/archive/v${WRF_VERSION}.tar.gz | tar zxC /comsoftware/wrf \
+ && curl -SL https://github.com/wrf-model/WPS/archive/v${WPS_VERSION}.tar.gz | tar zxC /comsoftware/wrf
 #
 # Set environment for interactive container shells
 #
-RUN echo export LDFLAGS="-lm" >> /etc/bashrc \
- && echo export NETCDF=/wrf/netcdf_links >> /etc/bashrc \
- && echo export JASPERINC=/usr/include/jasper/ >> /etc/bashrc \
- && echo export JASPERLIB=/usr/lib64/ >> /etc/bashrc \
- && echo export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib" >> /etc/bashrc \
- && echo export PATH="/usr/lib64/openmpi/bin:$PATH" >> /etc/bashrc \
- && echo setenv LDFLAGS "-lm" >> /etc/csh.cshrc \
- && echo setenv NETCDF "/wrf/netcdf_links" >> /etc/csh.cshrc \
- && echo setenv JASPERINC "/usr/include/jasper/" >> /etc/csh.cshrc \
- && echo setenv JASPERLIB "/usr/lib64/" >> /etc/csh.cshrc \
- && echo setenv LD_LIBRARY_PATH "/usr/lib64/openmpi/lib" >> /etc/csh.cshrc \
- && echo setenv PATH "/usr/lib64/openmpi/bin:$PATH" >> /etc/csh.cshrc
+RUN echo export LDFLAGS="-lm" >> /home/.bashrc \
+ && echo export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib" >> /home/.bashrc \
+ && echo export PATH="/usr/lib64/openmpi/bin:$PATH" >> /home/.bashrc \
+ && echo setenv LDFLAGS "-lm" >> /home/.cshrc \
+ && echo setenv LD_LIBRARY_PATH "/usr/lib64/openmpi/lib" >> /home/.cshrc \
+ && echo setenv PATH "/usr/lib64/openmpi/bin:$PATH" >> /home/.cshrc
 #
 # Build WRF first
 # input 34 and 1 to configure script alternative line = && echo -e "34\r1\r" | ./configure
 # 
 RUN pwd \ 
- && mkdir netcdf_links \
- && ln -sf /usr/include/openmpi-x86_64/ netcdf_links/include \
- && ln -sf /usr/lib64/openmpi/lib netcdf_links/lib \
- && export NETCDF=/wrf/netcdf_links \
+ && export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
  && cd ./WRF-${WRF_VERSION} \
@@ -55,7 +38,7 @@ RUN pwd \
 #
 # input 1 to configure script (gfortran serial build)
 RUN cd ./WPS-${WPS_VERSION} \
- && export NETCDF=/wrf/netcdf_links \
+ && echo export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
  && ./configure <<< $'1\r' \
@@ -65,29 +48,32 @@ RUN cd ./WPS-${WPS_VERSION} \
 ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib
 ENV PATH  /usr/lib64/openmpi/bin:$PATH
 #
-# copy in a couple custom scripts
+# copy in a couple custom scripts...apparently there's no way to docker COPY with non-root permissions....
 #
-COPY docker-clean /wrf
-#### KATE TODO: CHANGE RUN SCRIPT NAME #####
-COPY run-wps-wrf /wrf
-RUN chmod +x /wrf/docker-clean \
- && chmod +x /wrf/run-wps-wrf
+USER root
+COPY docker-clean /comsoftware/wrf
+COPY run-wps-wrf /comsoftware/wrf
+RUN chmod +x /comsoftware/wrf/docker-clean \
+ && chmod +x /comsoftware/wrf/run-wps-wrf \
+ && chown comuser:comusers /comsoftware/wrf/docker-clean \
+ && chown comuser:comusers /comsoftware/wrf/run-wps-wrf 
+USER comuser
 #
 # set up ssh configuration
 #
-COPY ssh_config /root/.ssh/config
-COPY slave /wrf/slave
-RUN yum install -y openssh-clients openssh-server net-tools \
-    && yum clean all \
-    && mkdir -p /var/run/sshd \
-    && ssh-keygen -A \
-    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
-    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
-    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-    && chmod 600 /root/.ssh/config \
-    && chmod 700 /root/.ssh \
-    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-    && chmod +x /wrf/slave
-
-CMD ["/wrf/run-wps-wrf"]
+#COPY ssh_config /root/.ssh/config
+#COPY slave /wrf/slave
+#RUN yum install -y openssh-clients openssh-server net-tools \
+#    && yum clean all \
+#    && mkdir -p /var/run/sshd \
+#    && ssh-keygen -A \
+#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /home/.ssh/sshd_config \
+#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /home/.ssh/sshd_config \
+#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /home/.ssh/sshd_config \
+#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
+#    && chmod 600 /root/.ssh/config \
+#    && chmod 700 /root/.ssh \
+#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
+#    && chmod +x /wrf/slave
+#
+CMD ["/comsoftware/wrf/run-wps-wrf"]


### PR DESCRIPTION
Converting the existing containers to use a common compilation container with pre-built libraries and standard compilers.

This effort also re-arranged the common directory structure of the different software and data containers. Now rather than a large number of top-level directories containing software, data, and scripts, the data that is not part of the operating system can now be found in three top-level directories:

* /comsoftware - contains software packages that are built in each container (e.g. /comsoftware/wrf, /comsoftware/met), as well as libraries that are specific to community software  (e.g. netCDF, BUFRLIB) which are built in the common compilation container under /comsoftware/libs
* /data - contains input data for different packages. Data containers will be mounted here.
* /home - contains scripts and working directories for each piece of software. Working directories (e.g. wpsprd, wrfprd, gsiprd, etc.) will be mounted here.

I also standardized the container permissions into a user known as 'comuser', rather than always running as root. This is considered best practice for security purposes (https://opensource.com/article/18/3/just-say-no-root-containers). This user has write permissions under /home, /comsoftware, and /data.

Runtime instructions needed to be changed for this new directory structure, and can be found in the updated README files. I am also working on putting the updated instructions online (not yet finished): https://dtcenter.org/community-code/numerical-weather-prediction-nwp-containers/tutorial-version-3