### PR TITLE
Auto-set uid to match inside and outside containers

### DIFF
--- a/components/base/Dockerfile
+++ b/components/base/Dockerfile
@@ -1,0 +1,17 @@
+FROM mkavulich/common-community-container:gnu7
+MAINTAINER Michael Kavulich <kavulich@ucar.edu>
+
+USER root
+
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && chmod +x /usr/local/bin/gosu
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/components/base/Dockerfile_simple
+++ b/components/base/Dockerfile_simple
@@ -1,0 +1,15 @@
+FROM centos:latest
+MAINTAINER Michael Kavulich <kavulich@ucar.edu>
+
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && rm -r /root/.gnupg/ \
+    && chmod +x /usr/local/bin/gosu
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/components/base/Dockerfile_simple
+++ b/components/base/Dockerfile_simple
@@ -1,6 +1,9 @@
 FROM centos:latest
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 
+RUN groupadd comusers -g 9999
+RUN useradd -u 9999 -g comusers -G wheel -M -d /home comuser
+
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \

--- a/components/base/entrypoint.sh
+++ b/components/base/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_ID=${LOCAL_USER_ID:-9999}
+
+echo "Starting with UID : $USER_ID"
+useradd --shell /bin/bash -u $USER_ID -g 9999 -o -c "" -m user
+
+exec /usr/local/bin/gosu user "$@"

--- a/components/base/entrypoint.sh
+++ b/components/base/entrypoint.sh
@@ -7,6 +7,6 @@
 USER_ID=${LOCAL_USER_ID:-9999}
 
 echo "Starting with UID : $USER_ID"
-useradd --shell /bin/bash -u $USER_ID -g 9999 -o -c "" -m user
+useradd --shell /bin/bash -u $USER_ID -g 9999 -o -c "" -m comuser
 
 exec /usr/local/bin/gosu comuser "$@"

--- a/components/base/entrypoint.sh
+++ b/components/base/entrypoint.sh
@@ -9,4 +9,4 @@ USER_ID=${LOCAL_USER_ID:-9999}
 echo "Starting with UID : $USER_ID"
 useradd --shell /bin/bash -u $USER_ID -g 9999 -o -c "" -m user
 
-exec /usr/local/bin/gosu user "$@"
+exec /usr/local/bin/gosu comuser "$@"

--- a/components/case_data/derecho_20120629/Dockerfile
+++ b/components/case_data/derecho_20120629/Dockerfile
@@ -1,11 +1,15 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
 ENV CASE_DIR /data
-
 RUN mkdir -p ${CASE_DIR} \
- && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-derechodata_20120629.tar.gz | tar -xzC ${CASE_DIR} \
- && chmod 6755 -R ${CASE_DIR}
+ && chown -R comuser:comusers ${CASE_DIR}
+USER comuser
+#
+RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-derechodata_20120629.tar.gz | tar -xzC ${CASE_DIR} \
+ && chmod 6775 ${CASE_DIR}
+#
 VOLUME $CASE_DIR
+USER root
 CMD ["true"]
 

--- a/components/case_data/sandy_20121027/Dockerfile
+++ b/components/case_data/sandy_20121027/Dockerfile
@@ -1,11 +1,15 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
-ENV CASE_DIR /data/
-
+ENV CASE_DIR /data
 RUN mkdir -p ${CASE_DIR} \
- && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-sandydata_20121027.tar.gz | tar -xzC ${CASE_DIR} \
- && chmod 6755 -R ${CASE_DIR}
+ && chown -R comuser:comusers ${CASE_DIR}
+USER comuser
+#
+RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-sandydata_20121027.tar.gz | tar -xzC ${CASE_DIR} \
+ && chmod 6775 ${CASE_DIR}
+#
 VOLUME $CASE_DIR
+USER root
 CMD ["true"]
 

--- a/components/case_data/snow_20160123/Dockerfile
+++ b/components/case_data/snow_20160123/Dockerfile
@@ -1,11 +1,15 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 MAINTAINER Jamie Wolff <jwolff@ucar.edu>
 
 ENV CASE_DIR /data
-
 RUN mkdir -p ${CASE_DIR} \
- && curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-snowdata_20160123.tar.gz | tar -xzC ${CASE_DIR} \
- && chmod 6755 -R ${CASE_DIR}
+ && chown -R comuser:comusers ${CASE_DIR}
+USER comuser
+#
+RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/container-dtc-nwp-snowdata_20160123.tar.gz | tar -xzC ${CASE_DIR} \
+ && chmod 6775 ${CASE_DIR}
+#
 VOLUME $CASE_DIR
+USER root
 CMD ["true"]
 

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:gnu7
+FROM dtcenter/base_image:latest
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
 # This Dockerfile compiles GSI from source during "docker build" step
@@ -63,4 +63,4 @@ RUN mkdir /home/gsi_run
 #    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
 #    && chmod +x /gsi/slave
 #
-CMD ["/home/gsiprd/run-gsi"]
+USER root

--- a/components/gsi/Dockerfile
+++ b/components/gsi/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
 # This Dockerfile compiles GSI from source during "docker build" step
 USER comuser
-RUN mkdir /comsoftware/gsi
+RUN umask 0002 \
+ && mkdir /comsoftware/gsi
 WORKDIR /comsoftware/gsi
 ENV GSI_VERSION 3.7
 ENV ENKF_VERSION 1.3
@@ -13,8 +14,8 @@ ENV J 4
 
 # Download source code
 #
-#RUN wget https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar zxC /comsoftware/gsi 
-RUN curl -SL https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar -xzC /comsoftware/gsi
+RUN umask 0002 \
+ && curl -SL https://dtcenter.org/com-GSI/users/downloads/GSI_releases/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION}.tar.gz | tar -xzC /comsoftware/gsi
 # Set necessary environment variables for GSI build
 #
 ENV LDFLAGS -lm
@@ -25,8 +26,7 @@ ENV HDF5_ROOT $NETCDF
 #
 # Prep GSI build
 # 
-RUN pwd \ 
- && env \
+RUN umask 0002 \
  && mkdir /comsoftware/gsi/gsi_build \
  && cd /comsoftware/gsi/gsi_build \
  && cmake /comsoftware/gsi/comGSIv${GSI_VERSION}_EnKFv${ENKF_VERSION} 
@@ -34,33 +34,15 @@ RUN pwd \
 #
 # Fix a few GSI bugs
 #
-RUN sed -i 's/wij(1)/wij/g' /comsoftware/gsi/comGSIv3.7_EnKFv1.3/src/setuplight.f90 \
+RUN umask 0002 \
+ && sed -i 's/wij(1)/wij/g' /comsoftware/gsi/comGSIv3.7_EnKFv1.3/src/setuplight.f90 \
  && sed -i 's/$/ -L\/comsoftware\/libs\/netcdf\/lib/g' /comsoftware/gsi/gsi_build/src/CMakeFiles/gsi.x.dir/link.txt \
  && sed -i 's/$/ -L\/comsoftware\/libs\/netcdf\/lib/g' /comsoftware/gsi/gsi_build/src/enkf/CMakeFiles/enkf_wrf.x.dir/link.txt
 #
 # Build GSI
 #
-RUN cd /comsoftware/gsi/gsi_build \
+RUN umask 0002 \
+ && cd /comsoftware/gsi/gsi_build \
  && make -j ${J} || echo "I think your build failed yo!"
-#
-# Setup run directory
-RUN mkdir /home/gsi_run
-#
-# set up ssh configuration
-#
-#COPY ssh_config /root/.ssh/config
-#COPY slave /gsi/slave
-#RUN apt install -y openssh-client openssh-server net-tools \
-#    && apt clean all \
-#    && mkdir -p /var/run/sshd \
-#    && ssh-keygen -A \
-#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
-#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
-#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
-#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-#    && chmod 600 /root/.ssh/config \
-#    && chmod 700 /root/.ssh \
-#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-#    && chmod +x /gsi/slave
 #
 USER root

--- a/components/gsi_data/Dockerfile
+++ b/components/gsi_data/Dockerfile
@@ -1,9 +1,12 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 #
-RUN mkdir -p /data/gsi
+RUN mkdir -p /data/gsi \
+ && chown -R comuser:comusers /data
+USER comuser
 #
 RUN curl -SL https://dtcenter.org/com-GSI/users/downloads/GSI_releases/CRTM_v2.3.0.tar.gz | tar -xzC /data/gsi/ \
- && chmod 6755 -R /data/gsi
+ && chmod 6775 -R /data/gsi
 VOLUME /data/gsi
+USER root
 CMD ["true"]

--- a/components/met/MET/Dockerfile
+++ b/components/met/MET/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:gnu7
+FROM dtcenter/base_image:latest
 MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 
 # 
@@ -87,3 +87,4 @@ RUN echo "Downloading met-${MET_VERSION} from ${MET_URL}" \
 #
 WORKDIR /comsoftware/met
 
+USER root

--- a/components/met/MET/Dockerfile
+++ b/components/met/MET/Dockerfile
@@ -54,17 +54,17 @@ ENV RSCRIPTS_BASE   /usr/local/share/comsoftware/met/Rscripts
 # Download GhostScript fonts
 #
 USER comuser
-RUN echo "Downloading GhostScript fonts from ${GSFONT_URL}" \
+RUN umask 0002 \
+ && echo "Downloading GhostScript fonts from ${GSFONT_URL}" \
  && curl -SL ${GSFONT_URL} | tar zxC /comsoftware/libs
 
 #
 # Download and compile MET source code
 #
-RUN echo "Downloading met-${MET_VERSION} from ${MET_URL}" \
+RUN umask 0002 \
+ && echo "Downloading met-${MET_VERSION} from ${MET_URL}" \
  && mkdir -p /comsoftware/met \
  && curl -SL ${MET_URL} | tar zxC /comsoftware/met \
-# && echo "Downloading met-${MET_VERSION} patches from ${PATCH_URL}" \
-# && curl -SL ${PATCH_URL} | tar zxC /comsoftware/met/met-${MET_VERSION} \
  && cd /comsoftware/met/met-${MET_VERSION} \
  && LOG_FILE=/comsoftware/met/met-${MET_VERSION}/configure.log \
  && echo "Configuring met-${MET_VERSION} and writing log file ${LOG_FILE}" \

--- a/components/metviewer/METviewer/Dockerfile
+++ b/components/metviewer/METviewer/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 
 MAINTAINER Tatiana Burek <tatiana@ucar.edu>
 

--- a/components/ncl/Dockerfile
+++ b/components/ncl/Dockerfile
@@ -2,8 +2,9 @@ FROM dtcenter/base_image:latest
 MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
 USER comuser
-RUN mkdir /home/nclprd
-RUN mkdir /home/wrfprd
+RUN umask 0002 \
+ && mkdir /home/nclprd \
+ && mkdir /home/wrfprd
 WORKDIR /home/nclprd
 USER root
 RUN yum -y update \

--- a/components/ncl/Dockerfile
+++ b/components/ncl/Dockerfile
@@ -1,6 +1,10 @@
-FROM mkavulich/common-community-container:gnu7
+FROM dtcenter/base_image:latest
 MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
+USER comuser
+RUN mkdir /home/nclprd
+RUN mkdir /home/wrfprd
+WORKDIR /home/nclprd
 USER root
 RUN yum -y update \
  && yum -y install fontconfig libgfortran libXext libXrender ImageMagick ksh
@@ -9,7 +13,3 @@ RUN curl -SL https://ral.ucar.edu/sites/default/files/public/projects/ncar-docke
 #
 ENV NCARG_ROOT /usr/local
 #
-USER comuser
-RUN mkdir /home/nclprd
-RUN mkdir /home/wrfprd
-WORKDIR /home/nclprd

--- a/components/upp/Dockerfile
+++ b/components/upp/Dockerfile
@@ -3,12 +3,14 @@ MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.ed
 # 
 # This Dockerfile compiles UPP from source during "docker build" step
 USER comuser
-RUN mkdir /comsoftware/upp
+RUN umask 0002 \
+ && mkdir /comsoftware/upp
 WORKDIR /comsoftware/upp
 ENV UPP_VERSION 4.0.1
  
 # Download original source
-RUN curl -SL https://dtcenter.org/sites/default/files/DTC_upp_v${UPP_VERSION}.tar.gz | tar zxC /comsoftware/upp
+RUN umask 0002 \
+ && curl -SL https://dtcenter.org/sites/default/files/DTC_upp_v${UPP_VERSION}.tar.gz | tar zxC /comsoftware/upp
 # Set environment for interactive container shells
 #
 RUN echo export LDFLAGS="-lm" >> /home/.bashrc \ 
@@ -33,7 +35,7 @@ RUN echo export LDFLAGS="-lm" >> /home/.bashrc \
 # Build UPP 
 # input 7 to configure script (for gfortran serial build)
 
-RUN pwd \
+RUN umask 0002 \
  && export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
@@ -44,23 +46,6 @@ RUN pwd \
 #
 ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
 ENV PATH /usr/lib64/openmpi/bin:$PATH
-#
-# set up ssh configuration
-#
-#COPY ssh_config /root/.ssh/config
-#COPY slave /upp/slave
-#RUN yum install -y openssh-clients openssh-server net-tools \
-#    && yum clean all \
-#    && mkdir -p /var/run/sshd \
-#    && ssh-keygen -A \
-#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /etc/ssh/sshd_config \
-#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /etc/ssh/sshd_config \
-#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /etc/ssh/sshd_config \
-#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-#    && chmod 600 /root/.ssh/config \
-#    && chmod 700 /root/.ssh \
-#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-#    && chmod +x /upp/slave
 #
 # copy in a custom script...apparently there's no way to docker COPY with non-root permissions....
 #

--- a/components/upp/Dockerfile
+++ b/components/upp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:gnu7
+FROM dtcenter/base_image:latest
 MAINTAINER Kate Fossell <fossell@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 # 
 # This Dockerfile compiles UPP from source during "docker build" step
@@ -45,14 +45,6 @@ RUN pwd \
 ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
 ENV PATH /usr/lib64/openmpi/bin:$PATH
 #
-# copy in a custom script...apparently there's no way to docker COPY with non-root permissions....
-#
-USER root
-COPY run-upp /comsoftware/upp
-RUN chmod +x /comsoftware/upp/run-upp \
- && chown comuser:comusers /comsoftware/upp/run-upp
-USER comuser
-#
 # set up ssh configuration
 #
 #COPY ssh_config /root/.ssh/config
@@ -69,5 +61,11 @@ USER comuser
 #    && chmod 700 /root/.ssh \
 #    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
 #    && chmod +x /upp/slave
+#
+# copy in a custom script...apparently there's no way to docker COPY with non-root permissions....
+#
+USER root
+COPY run-upp /comsoftware/upp
+RUN chmod +x /comsoftware/upp/run-upp \
+ && chown comuser:comusers /comsoftware/upp/run-upp
 
-CMD ["/upp/run-upp"]

--- a/components/wps_geog/Dockerfile
+++ b/components/wps_geog/Dockerfile
@@ -1,9 +1,12 @@
-FROM centos:latest
+FROM dtcenter/base_image:simple
 MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 #
-RUN mkdir -p /data/WPS_GEOG
+RUN mkdir -p /data/WPS_GEOG \
+ && chown -R comuser:comusers /data
+USER comuser
 #
 RUN curl -SL http://www.dtcenter.org/eval/meso_mod/mmet/data_for_docker/geog_minimum.tar.gz | tar -xzC /data/WPS_GEOG \
- && chmod 6755 -R /data/WPS_GEOG
+ && chmod 6775 -R /data/WPS_GEOG
 VOLUME /data/WPS_GEOG
+USER root
 CMD ["true"]

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -3,14 +3,16 @@ MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 # 
 # This Dockerfile compiles WRF from source during "docker build" step
 USER comuser
-RUN mkdir /comsoftware/wrf
+RUN umask 0002 \
+ && mkdir /comsoftware/wrf
 WORKDIR /comsoftware/wrf
 ENV WRF_VERSION 4.1.1
 ENV WPS_VERSION 4.1
 #
 # Download original sources
 #
-RUN curl -SL https://github.com/wrf-model/WRF/archive/v${WRF_VERSION}.tar.gz | tar zxC /comsoftware/wrf \
+RUN umask 0002 \
+ && curl -SL https://github.com/wrf-model/WRF/archive/v${WRF_VERSION}.tar.gz | tar zxC /comsoftware/wrf \
  && curl -SL https://github.com/wrf-model/WPS/archive/v${WPS_VERSION}.tar.gz | tar zxC /comsoftware/wrf
 #
 # Set environment for interactive container shells
@@ -25,7 +27,7 @@ RUN echo export LDFLAGS="-lm" >> /home/.bashrc \
 # Build WRF first
 # input 34 and 1 to configure script alternative line = && echo -e "34\r1\r" | ./configure
 # 
-RUN pwd \ 
+RUN umask 0002 \ 
  && export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
  && export JASPERLIB=/usr/lib64/ \
@@ -41,7 +43,8 @@ RUN ls /comsoftware/wrf/WRF-${WRF_VERSION}/main/real.exe /comsoftware/wrf/WRF-${
 # Build WPS second
 #
 # input 1 to configure script (gfortran serial build)
-RUN ln -sf WRF-${WRF_VERSION} WRF \
+RUN umask 0002 \
+ && ln -sf WRF-${WRF_VERSION} WRF \
  && cd ./WPS-${WPS_VERSION} \
  && echo export NETCDF=/comsoftware/libs/netcdf/ \
  && export JASPERINC=/usr/include/jasper/ \
@@ -54,24 +57,6 @@ RUN ls /comsoftware/wrf/WPS-${WPS_VERSION}/metgrid.exe /comsoftware/wrf/WPS-${WP
 #
 ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
 ENV PATH  /usr/lib64/openmpi/bin:$PATH
-#
-# set up ssh configuration
-#
-#COPY ssh_config /root/.ssh/config
-#COPY slave /wrf/slave
-#RUN yum install -y openssh-clients openssh-server net-tools \
-#    && yum clean all \
-#    && mkdir -p /var/run/sshd \
-#    && ssh-keygen -A \
-#    && sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/g' /home/.ssh/sshd_config \
-#    && sed -i 's/#RSAAuthentication yes/RSAAuthentication yes/g' /home/.ssh/sshd_config \
-#    && sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/g' /home/.ssh/sshd_config \
-#    && ssh-keygen -f /root/.ssh/id_rsa -t rsa -N '' \
-#    && chmod 600 /root/.ssh/config \
-#    && chmod 700 /root/.ssh \
-#    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
-#    && chmod +x /wrf/slave
-#
 #
 # copy in a couple custom scripts...apparently there's no way to docker COPY with non-root permissions....
 #

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -1,4 +1,4 @@
-FROM mkavulich/common-community-container:gnu7
+FROM dtcenter/base_image:latest
 MAINTAINER Jamie Wolff <jwolff@ucar.edu> or Michelle Harrold <harrold@ucar.edu>
 # 
 # This Dockerfile compiles WRF from source during "docker build" step
@@ -55,17 +55,6 @@ RUN ls /comsoftware/wrf/WPS-${WPS_VERSION}/metgrid.exe /comsoftware/wrf/WPS-${WP
 ENV LD_LIBRARY_PATH /usr/lib64/openmpi/lib:/comsoftware/libs/netcdf/lib
 ENV PATH  /usr/lib64/openmpi/bin:$PATH
 #
-# copy in a couple custom scripts...apparently there's no way to docker COPY with non-root permissions....
-#
-USER root
-COPY docker-clean /comsoftware/wrf
-COPY run-wps-wrf /comsoftware/wrf
-RUN chmod +x /comsoftware/wrf/docker-clean \
- && chmod +x /comsoftware/wrf/run-wps-wrf \
- && chown comuser:comusers /comsoftware/wrf/docker-clean \
- && chown comuser:comusers /comsoftware/wrf/run-wps-wrf 
-USER comuser
-#
 # set up ssh configuration
 #
 #COPY ssh_config /root/.ssh/config
@@ -83,4 +72,13 @@ USER comuser
 #    && cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys \
 #    && chmod +x /wrf/slave
 #
-CMD ["/comsoftware/wrf/run-wps-wrf"]
+#
+# copy in a couple custom scripts...apparently there's no way to docker COPY with non-root permissions....
+#
+USER root
+COPY docker-clean /comsoftware/wrf
+COPY run-wps-wrf /comsoftware/wrf
+RUN chmod +x /comsoftware/wrf/docker-clean \
+ && chmod +x /comsoftware/wrf/run-wps-wrf \
+ && chown comuser:comusers /comsoftware/wrf/docker-clean \
+ && chown comuser:comusers /comsoftware/wrf/run-wps-wrf


### PR DESCRIPTION
This set of changes should hopefully eliminate some of the weird issues we have seen with docker on AWS. The basic gist of these changes is three-fold:

1. Build *all* containers from a "base" image, that uses Docker's ENTRYPOINT functionality to force each docker run instance to use a specific uid that can be specified at runtime. This will allow us to match the uid inside the container with the uid outside the container, which should eliminate problems where users can not modify files created inside the container when they are outside of the container, and vice-versa
2. Since this base image starts with the common container that we hope to use across other projects (https://github.com/NCAR/CCCP), but we don't want all our containers to be bloated with unnecessary software (metviewer and especially data containers), there are two versions of this base container: one base Dockerfile (that starts from the cccp image), and a Dockerfile_simple (that starts from the base centos image).
3. All software, data, and other files/directories that the user may need to modify are set to 6775 permissions (user and group can read/write/execute) so that regardless of what the uid is set to at run time, the common gid (always set to 9999 in all images) will allow the user to use and modify those files

I have not finished testing this locally, but I will merge this pull request once those tests are completed