### PR TITLE
Fix for WPS_GEOG data + Python wind barbs

### DIFF
--- a/components/scripts/common/python/ALL_plot_allvars.py
+++ b/components/scripts/common/python/ALL_plot_allvars.py
@@ -543,10 +543,14 @@ def plot_all(dom):
   clear_plotables(ax,keep_ax_lst,fig)
 
   units = 'kts'
-  # Places a wind barb every ~180 km, optimized for CONUS domain
-  skip = round(177.28*(dx/1000.)**-.97)
-  print('skipping every '+str(skip)+' grid points to plot')
-  barblength = 4
+  if dx < 5000:
+    skip = round(75.*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
+  else:
+    skip = round(177.28*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
 
   clevs = [5,10,15,20,25,30,35,40,45,50,55,60]
   colorlist = ['turquoise','dodgerblue','blue','#FFF68F','#E3CF57','peru','brown','crimson','red','fuchsia','DarkViolet']
@@ -611,10 +615,14 @@ def plot_all(dom):
 #  clear_plotables(ax,keep_ax_lst,fig)
 #
 #  units = 'x10${^5}$ s${^{-1}}$'
-## Places a wind barb every ~180 km, optimized for CONUS domain
-#  skip = round(177.28*(dx/1000.)**-.97)
-#  print('skipping every '+str(skip)+' grid points to plot')
-#  barblength = 4
+#  if dx < 5000:
+#    skip = round(75.*(dx/1000.)**-.97)
+#    print('skipping every '+str(skip)+' grid points to plot')
+#    barblength = 4
+#  else:
+#    skip = round(177.28*(dx/1000.)**-.97)
+#    print('skipping every '+str(skip)+' grid points to plot')
+#    barblength = 4
 #
 #  vortlevs = [16,20,24,28,32,36,40]
 #  colorlist = ['yellow','gold','goldenrod','orange','orangered','red']
@@ -649,10 +657,14 @@ def plot_all(dom):
   clear_plotables(ax,keep_ax_lst,fig)
 
   units = 'kts'
-  # Places a wind barb every ~180 km, optimized for CONUS domain
-  skip = round(177.28*(dx/1000.)**-.97)
-  print('skipping every '+str(skip)+' grid points to plot')
-  barblength = 4
+  if dx < 5000:
+    skip = round(75.*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
+  else:
+    skip = round(177.28*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
 
   clevs = [50,60,70,80,90,100,110,120,130,140,150]
   colorlist = ['turquoise','deepskyblue','dodgerblue','#1874CD','blue','beige','khaki','peru','brown','crimson']

--- a/components/scripts/common/python/ALL_plot_allvars.py
+++ b/components/scripts/common/python/ALL_plot_allvars.py
@@ -543,7 +543,9 @@ def plot_all(dom):
   clear_plotables(ax,keep_ax_lst,fig)
 
   units = 'kts'
-  skip = 50
+  # Places a wind barb every ~180 km, optimized for CONUS domain
+  skip = round(177.28*(dx/1000.)**-.97)
+  print('skipping every '+str(skip)+' grid points to plot')
   barblength = 4
 
   clevs = [5,10,15,20,25,30,35,40,45,50,55,60]
@@ -609,7 +611,9 @@ def plot_all(dom):
 #  clear_plotables(ax,keep_ax_lst,fig)
 #
 #  units = 'x10${^5}$ s${^{-1}}$'
-#  skip = 70
+## Places a wind barb every ~180 km, optimized for CONUS domain
+#  skip = round(177.28*(dx/1000.)**-.97)
+#  print('skipping every '+str(skip)+' grid points to plot')
 #  barblength = 4
 #
 #  vortlevs = [16,20,24,28,32,36,40]
@@ -645,7 +649,9 @@ def plot_all(dom):
   clear_plotables(ax,keep_ax_lst,fig)
 
   units = 'kts'
-  skip = 70
+  # Places a wind barb every ~180 km, optimized for CONUS domain
+  skip = round(177.28*(dx/1000.)**-.97)
+  print('skipping every '+str(skip)+' grid points to plot')
   barblength = 4
 
   clevs = [50,60,70,80,90,100,110,120,130,140,150]

--- a/components/scripts/common/python/plot_10mW.py
+++ b/components/scripts/common/python/plot_10mW.py
@@ -361,10 +361,14 @@ def plot_all(dom):
   print(('Working on 10mwspd for '+dom))
 
   units = 'kts'
-  # Places a wind barb every ~180 km, optimized for CONUS domain
-  skip = round(177.28*(dx/1000.)**-.97)
-  print('skipping every '+str(skip)+' grid points to plot')
-  barblength = 4
+  if dx < 5000:
+    skip = round(75.*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
+  else:
+    skip = round(177.28*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
 
   clevs = [5,10,15,20,25,30,35,40,45,50,55,60]
   colorlist = ['turquoise','dodgerblue','blue','#FFF68F','#E3CF57','peru','brown','crimson','red','fuchsia','DarkViolet']

--- a/components/scripts/common/python/plot_10mW.py
+++ b/components/scripts/common/python/plot_10mW.py
@@ -361,7 +361,9 @@ def plot_all(dom):
   print(('Working on 10mwspd for '+dom))
 
   units = 'kts'
-  skip = 50
+  # Places a wind barb every ~180 km, optimized for CONUS domain
+  skip = round(177.28*(dx/1000.)**-.97)
+  print('skipping every '+str(skip)+' grid points to plot')
   barblength = 4
 
   clevs = [5,10,15,20,25,30,35,40,45,50,55,60]

--- a/components/scripts/common/python/plot_250mbW.py
+++ b/components/scripts/common/python/plot_250mbW.py
@@ -361,7 +361,9 @@ def plot_all(dom):
   print(('Working on 250 mb WIND for '+dom))
 
   units = 'kts'
-  skip = 70
+  # Places a wind barb every ~180 km, optimized for CONUS domain
+  skip = round(177.28*(dx/1000.)**-.97)
+  print('skipping every '+str(skip)+' grid points to plot')
   barblength = 4
 
   clevs = [50,60,70,80,90,100,110,120,130,140,150]

--- a/components/scripts/common/python/plot_250mbW.py
+++ b/components/scripts/common/python/plot_250mbW.py
@@ -361,10 +361,14 @@ def plot_all(dom):
   print(('Working on 250 mb WIND for '+dom))
 
   units = 'kts'
-  # Places a wind barb every ~180 km, optimized for CONUS domain
-  skip = round(177.28*(dx/1000.)**-.97)
-  print('skipping every '+str(skip)+' grid points to plot')
-  barblength = 4
+  if dx < 5000:
+    skip = round(75.*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
+  else:
+    skip = round(177.28*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
 
   clevs = [50,60,70,80,90,100,110,120,130,140,150]
   colorlist = ['turquoise','deepskyblue','dodgerblue','#1874CD','blue','beige','khaki','peru','brown','crimson']

--- a/components/scripts/common/python/plot_500mbH_W_Vort.py
+++ b/components/scripts/common/python/plot_500mbH_W_Vort.py
@@ -365,10 +365,14 @@ def plot_all(dom):
   print(('Working on 500 mb Hgt/Wind/Vort for '+dom))
 
   units = 'x10${^5}$ s${^{-1}}$'
-  # Places a wind barb every ~180 km, optimized for CONUS domain
-  skip = round(177.28*(dx/1000.)**-.97)
-  print('skipping every '+str(skip)+' grid points to plot')
-  barblength = 4
+  if dx < 5000:
+    skip = round(75.*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
+  else:
+    skip = round(177.28*(dx/1000.)**-.97)
+    print('skipping every '+str(skip)+' grid points to plot')
+    barblength = 4
 
   vortlevs = [16,20,24,28,32,36,40]
   colorlist = ['yellow','gold','goldenrod','orange','orangered','red']

--- a/components/scripts/common/python/plot_500mbH_W_Vort.py
+++ b/components/scripts/common/python/plot_500mbH_W_Vort.py
@@ -365,7 +365,9 @@ def plot_all(dom):
   print(('Working on 500 mb Hgt/Wind/Vort for '+dom))
 
   units = 'x10${^5}$ s${^{-1}}$'
-  skip = 70
+  # Places a wind barb every ~180 km, optimized for CONUS domain
+  skip = round(177.28*(dx/1000.)**-.97)
+  print('skipping every '+str(skip)+' grid points to plot')
   barblength = 4
 
   vortlevs = [16,20,24,28,32,36,40]

--- a/components/scripts/derecho_20120629/namelist.input
+++ b/components/scripts/derecho_20120629/namelist.input
@@ -87,7 +87,7 @@
  cudt                                = 0, 0,
  surface_input_source                = 1,
  num_soil_layers                     = 9,
- num_land_cat                        = 24,
+ num_land_cat                        = 21,
  maxiens                             = 1,
  maxens                              = 3,
  maxens2                             = 3,

--- a/components/scripts/derecho_20120629/namelist.wps
+++ b/components/scripts/derecho_20120629/namelist.wps
@@ -14,7 +14,7 @@
  j_parent_start    =   1,  20,
  e_we              = 101, 49,
  e_sn              = 76,  49,
- geog_data_res     = '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac', '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac'
+ geog_data_res     = 'lowres', 'lowres',
  dx = 12000,
  dy = 12000,
  map_proj = 'lambert',

--- a/components/scripts/sandy_20121027/namelist.input
+++ b/components/scripts/sandy_20121027/namelist.input
@@ -70,7 +70,7 @@
  icloud                              = 1,
  surface_input_source                = 1,
  num_soil_layers                     = 4,
- num_land_cat                        = 24,
+ num_land_cat                        = 21,
  sf_urban_physics                    = 0,     0,     0,
  do_radar_ref                        = 1,
  /

--- a/components/scripts/sandy_20121027/namelist.wps
+++ b/components/scripts/sandy_20121027/namelist.wps
@@ -14,7 +14,7 @@
  j_parent_start    =   1,  17,
  e_we              = 50, 112,
  e_sn              = 50,  97,
- geog_data_res     = '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac', '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac'
+ geog_data_res     = 'lowres', 'lowres',
  dx = 40000,
  dy = 40000,
  map_proj = 'lambert',

--- a/components/scripts/snow_20160123/namelist.input
+++ b/components/scripts/snow_20160123/namelist.input
@@ -76,7 +76,7 @@
  sf_urban_physics                    = 0,     0,     0,
  surface_input_source                = 1,
  num_soil_layers                     = 9,
- num_land_cat                        = 24,
+ num_land_cat                        = 21,
  maxiens                             = 1,
  maxens                              = 3,
  maxens2                             = 3,

--- a/components/scripts/snow_20160123/namelist.wps
+++ b/components/scripts/snow_20160123/namelist.wps
@@ -14,7 +14,7 @@
  j_parent_start    =   1,  17,
  e_we              = 175, 112,
  e_sn              = 100,  97,
- geog_data_res     = '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac', '2deg+gtopo_10m+usgs_10m+10m+nesdis_greenfrac'
+ geog_data_res     = 'lowres', 'lowres',
  dx = 30000,
  dy = 30000,
  map_proj = 'lambert',


### PR DESCRIPTION
This PR address two issues:
[Issue 26](https://github.com/NCAR/container-dtc-nwp/issues/26): Addressing issue with wind field when using slimmed down WPS GEOG data
[Issue 28](https://github.com/NCAR/container-dtc-nwp/issues/28): Addressing issue with wind barbs not plotting correctly with Python scripts

Fixes:
When moving to WRFv4+, the minimum WPS GEOG dataset changed. Using the new dataset, in combination with modifications to the namelist.wps and namelist.input files for each case, fixes the wind field issues. This PR changes the geog_data_res in namelist.wps and num_land_cat in namelist.input. As a note, the wps_geog.tar.gz file has been updated in the DTC website and on Cheyenne.

The original plotting scripts had very few wind barbs. Modifications were made to the wind-related scripts, based on changes to scripts with the UFS-SRW app, to allow for more appropriate spacing between wind barbs.

Tests:
I tested these changes on my local Mac for all three cases. Notes:

- I didn't test with GSI
- I didn't test for backwards compatibility with WRFv3. Do we want to provide the old set of files for use with previous tags?
