### PR TITLE
Feature/issue 7 run script

### DIFF
--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -63,7 +63,7 @@ CASE_SCRIPT=`basename ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NA
 # Setup the environment
 RUN_CMD export CASE_DIR=${PROJ_DIR}/${CASE_NAME}
 RUN_CMD mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
-RUN_CMD mkdir -p wpsprd wrfprd gsiprd postprd nclprd metprd metviewer/mysql
+RUN_CMD mkdir -p wpsprd wrfprd gsiprd postprd pythonprd metprd metviewer/mysql
 
 # Run WPS
 RUN_CMD \

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -33,7 +33,7 @@ SCRIPT_DIR=`dirname $0`
 export RUN_CMD=${SCRIPT_DIR}/run_command.ksh
 
 # Setup the environment
-${RUN_CMD} setenv CASE_DIR ${PROJ_DIR}/${CASE_NAME}; mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
+${RUN_CMD} export CASE_DIR=${PROJ_DIR}/${CASE_NAME}; mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
 ${RUN_CMD} mkdir -p wpsprd wrfprd gsiprd postprd nclprd metprd metviewer/mysql
 
 # Run WPS

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -140,6 +140,11 @@ if [ -n "${IS_AWS}" ]; then
 else
   RUN_CMD docker-compose up -d
 fi
+
+# Sleep for 2 minutes before loading data
+RUN_CMD sleep 120
+
+# Load data into METviewer
 RUN_CMD docker exec -it metviewer /scripts/common/metv_load_all.ksh mv_${CASE_NAME}
 
 # Run METviewer to create plots

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -152,7 +152,7 @@ RUN_CMD docker exec -it metviewer /scripts/common/metv_load_all.ksh mv_${CASE_NA
 
 # Run METviewer to create plots
 for XML_FILE in `ls ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}/metviewer/*.xml`; do
-  RUN_CMD docker exec -it metviewer /METviewer/bin/mv_batch.sh /scripts/case/metviewer/`basename ${XML_FILE}`
+  RUN_CMD docker exec -it metviewer /METviewer/bin/mv_batch.sh /scripts/${CASE_SCRIPT}/metviewer/`basename ${XML_FILE}`
 done
 
 echo "Done with the ${CASE_NAME} case."

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -33,7 +33,8 @@ SCRIPT_DIR=`dirname $0`
 export RUN_CMD=${SCRIPT_DIR}/run_command.ksh
 
 # Setup the environment
-${RUN_CMD} export CASE_DIR=${PROJ_DIR}/${CASE_NAME}; mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
+${RUN_CMD} export CASE_DIR=${PROJ_DIR}/${CASE_NAME}
+${RUN_CMD} mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
 ${RUN_CMD} mkdir -p wpsprd wrfprd gsiprd postprd nclprd metprd metviewer/mysql
 
 # Run WPS

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -152,7 +152,7 @@ RUN_CMD docker exec -it metviewer /scripts/common/metv_load_all.ksh mv_${CASE_NA
 
 # Run METviewer to create plots
 for XML_FILE in `ls ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}/metviewer/*.xml`; do
-  RUN_CMD docker exec -it metviewer /METviewer/bin/mv_batch.sh /home/scripts/case/metviewer/`basename ${XML_FILE}`
+  RUN_CMD docker exec -it metviewer /METviewer/bin/mv_batch.sh /scripts/case/metviewer/`basename ${XML_FILE}`
 done
 
 echo "Done with the ${CASE_NAME} case."

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -54,8 +54,8 @@ RUN_CMD () {
   fi
 }
 
-# Locate run_command.ksh script 
-SCRIPT_DIR=`dirname $0`
+# Locate case-specific scripts
+CASE_SCRIPT=`basename ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*`
 
 # Setup the environment
 RUN_CMD export CASE_DIR=${PROJ_DIR}/${CASE_NAME}
@@ -68,7 +68,7 @@ docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/data/WPS_GEOG:/data/WPS_GEOG \
 -v ${PROJ_DIR}/container-dtc-nwp/data:/data \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/wpsprd:/home/wpsprd \
 --name run-${CASE_NAME}-wps dtcenter/wps_wrf:3.4 \
 /home/scripts/common/run_wps.ksh
@@ -78,7 +78,7 @@ RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/data:/data \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/wpsprd:/home/wpsprd \
 -v ${CASE_DIR}/wrfprd:/home/wrfprd \
 --name run-${CASE_NAME}-real dtcenter/wps_wrf:3.4 \
@@ -89,7 +89,7 @@ RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/data:/data \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/gsiprd:/home/gsiprd \
 -v ${CASE_DIR}/wrfprd:/home/wrfprd \
 --name run-${CASE_NAME}-gsi dtcenter/gsi:3.4 \
@@ -99,7 +99,7 @@ docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
  -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+ -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
  -v ${CASE_DIR}/wpsprd:/home/wpsprd \
  -v ${CASE_DIR}/gsiprd:/home/gsiprd \
  -v ${CASE_DIR}/wrfprd:/home/wrfprd \
@@ -109,7 +109,7 @@ docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/wrfprd:/home/wrfprd \
 -v ${CASE_DIR}/postprd:/home/postprd \
 --name run-${CASE_NAME}-upp dtcenter/upp:3.4 /home/scripts/common/run_upp.ksh
@@ -118,7 +118,7 @@ docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/postprd:/home/postprd \
 -v ${CASE_DIR}/pythonprd:/home/pythonprd \
 --name run-${CASE_NAME}-python dtcenter/python:3.4 /home/scripts/common/run_python.ksh
@@ -128,7 +128,7 @@ RUN_CMD \
 docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 -v ${PROJ_DIR}/container-dtc-nwp/data:/data \
 -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
--v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}:/home/scripts/case \
 -v ${CASE_DIR}/postprd:/home/postprd \
 -v ${CASE_DIR}/metprd:/home/metprd \
 --name run-${CASE_NAME}-met dtcenter/nwp-container-met:3.4 /home/scripts/common/run_met.ksh
@@ -143,7 +143,7 @@ fi
 RUN_CMD docker exec -it metviewer /scripts/common/metv_load_all.ksh mv_${CASE_NAME}
 
 # Run METviewer to create plots
-for XML_FILE in `ls ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*/metviewer/*.xml`; do
+for XML_FILE in `ls ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_SCRIPT}/metviewer/*.xml`; do
   RUN_CMD docker exec -it metviewer /METviewer/bin/mv_batch.sh /home/scripts/case/metviewer/`basename ${XML_FILE}`
 done
 

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -22,6 +22,12 @@ if [ $# -ne 1 ]; then
 fi
 CASE_NAME=$1
 
+# Determine if on AWS based on the user name
+if [ $USER == "ec2-user" ]; then
+  echo "Running on AWS."
+  IS_AWS="true"
+fi
+
 # Locate run_command.ksh script 
 SCRIPT_DIR=`dirname $0`
 export RUN_CMD=${SCRIPT_DIR}/run_command.ksh
@@ -30,65 +36,84 @@ export RUN_CMD=${SCRIPT_DIR}/run_command.ksh
 ${RUN_CMD} setenv CASE_DIR ${PROJ_DIR}/${CASE_NAME}; mkdir -p ${CASE_DIR}; cd ${CASE_DIR}
 ${RUN_CMD} mkdir -p wpsprd wrfprd gsiprd postprd nclprd metprd metviewer/mysql
 
-# Run WPS 
+# Run WPS
 ${RUN_CMD} time \
- docker run --rm -it --volumes-from wps_geog --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/wpsprd:/home/wpsprd \
- --name run-${CASE_NAME}-wps dtc-wps_wrf /home/scripts/common/run_wps.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/data/WPS_GEOG:/data/WPS_GEOG \
+-v ${PROJ_DIR}/container-dtc-nwp/data:/data \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/wpsprd:/home/wpsprd \
+--name run-${CASE_NAME}-wps dtcenter/wps_wrf:3.4 \
+/home/scripts/common/run_wps.ksh
 
 # Run Real
 ${RUN_CMD} time \
- docker run --rm -it --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
- --name run-${CASE_NAME}-real dtc-wps_wrf /home/scripts/common/run_real.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/data:/data \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/wpsprd:/home/wpsprd \
+-v ${CASE_DIR}/wrfprd:/home/wrfprd \
+--name run-${CASE_NAME}-real dtcenter/wps_wrf:3.4 \
+/home/scripts/common/run_real.ksh
 
 # Run GSI
 ${RUN_CMD} time \
- docker run --rm -it --volumes-from gsi_data --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/gsiprd:/home/gsiprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
- --name run-${CASE_NAME}-gsi dtc-gsi /home/scripts/common/run_gsi.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/data:/data \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/gsiprd:/home/gsiprd \
+-v ${CASE_DIR}/wrfprd:/home/wrfprd \
+--name run-${CASE_NAME}-gsi dtcenter/gsi:3.4 \
+/home/scripts/common/run_gsi.ksh
 
 # Run WRF
 ${RUN_CMD} time \
- docker run --rm -it \
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
  -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
  -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/gsiprd:/home/gsiprd -v ${CASE_DIR}/wrfprd:/home/wrfprd \
- --name run-${CASE_NAME}-wrf dtc-wps_wrf /home/scripts/common/run_wrf.ksh
+ -v ${CASE_DIR}/wpsprd:/home/wpsprd \
+ -v ${CASE_DIR}/gsiprd:/home/gsiprd \
+ -v ${CASE_DIR}/wrfprd:/home/wrfprd \
+ --name run-${CASE_NAME}-wrf dtcenter/wps_wrf:3.4 /home/scripts/common/run_wrf.ksh
 
 # Run UPP 
 ${RUN_CMD} time \
- docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/postprd:/home/postprd \
- --name run-${CASE_NAME}-upp dtc-upp /home/scripts/common/run_upp.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/wrfprd:/home/wrfprd \
+-v ${CASE_DIR}/postprd:/home/postprd \
+--name run-${CASE_NAME}-upp dtcenter/upp:3.4 /home/scripts/common/run_upp.ksh
 
 # Run NCL
 ${RUN_CMD} time \
- docker run --rm -it \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/wpsprd:/home/wpsprd -v ${CASE_DIR}/wrfprd:/home/wrfprd -v ${CASE_DIR}/nclprd:/home/nclprd \
- --name run-${CASE_NAME}-ncl dtc-ncl /home/scripts/common/run_ncl.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/postprd:/home/postprd \
+-v ${CASE_DIR}/pythonprd:/home/pythonprd \
+--name run-${CASE_NAME}-python dtcenter/python:3.4 /home/scripts/common/run_python.ksh
 
 # Run MET
 ${RUN_CMD} time \
- docker run --rm -it --volumes-from ${CASE_NAME} \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
- -v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
- -v ${CASE_DIR}/postprd:/home/postprd -v ${CASE_DIR}/metprd:/home/metprd \
- --name run-${CASE_NAME}-met dtc-met /home/scripts/common/run_met.ksh
+docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
+-v ${PROJ_DIR}/container-dtc-nwp/data:/data \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
+-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/${CASE_NAME}*:/home/scripts/case \
+-v ${CASE_DIR}/postprd:/home/postprd \
+-v ${CASE_DIR}/metprd:/home/metprd \
+--name run-${CASE_NAME}-met dtcenter/nwp-container-met:3.4 /home/scripts/common/run_met.ksh
 
 # Load MET output into METviewer
 ${RUN_CMD} cd ${PROJ_DIR}/container-dtc-nwp/components/metviewer
-${RUN_CMD} docker-compose up -d
+if [ -n "${IS_AWS}" ]; then
+  ${RUN_CMD} time docker-compose -f docker-compose-AWS.yml up -d
+else
+  ${RUN_CMD} time docker-compose up -d
+fi
 ${RUN_CMD} time docker exec -it metviewer /scripts/common/metv_load_all.ksh mv_${CASE_NAME}
 
 # Run METviewer to create plots

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -40,7 +40,7 @@ RUN_CMD () {
 
   # Run the command
   echo
-  echo "CALLING: time $*"
+  echo "RUNNING: time $*"
   echo
   time $*
 

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -5,6 +5,15 @@
 # This script should be run OUTSIDE of the containers.
 #
 
+# Determine if on AWS based on the user name
+if [ $USER == "ec2-user" ]; then
+  IS_AWS="true"
+  echo "Running on AWS."
+  if [[ ! -e $PROJ_DIR ]]; then
+    export PROJ_DIR="/home/ec2-user"
+  fi
+fi
+
 # Make sure that ${PROJ_DIR} has been set
 if [[ ! -e $PROJ_DIR ]]; then
   echo 
@@ -21,12 +30,6 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 CASE_NAME=$1
-
-# Determine if on AWS based on the user name
-if [ $USER == "ec2-user" ]; then
-  echo "Running on AWS."
-  IS_AWS="true"
-fi
 
 # Function for executing and timing commands
 RUN_CMD () {

--- a/components/scripts/common/docker_run_case.ksh
+++ b/components/scripts/common/docker_run_case.ksh
@@ -138,7 +138,7 @@ docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
 
 # Load MET output into METviewer
 RUN_CMD cd ${PROJ_DIR}/container-dtc-nwp/components/metviewer
-if [ -n "${IS_AWS}" ]; then
+if [[ -e $IS_AWS ]]; then
   RUN_CMD docker-compose -f docker-compose-AWS.yml up -d
 else
   RUN_CMD docker-compose up -d


### PR DESCRIPTION
Made several updates to components/scripts/common/docker_run_case.ksh:
- Defined RUN_CMD function locally so that are error there causes the run script to actually error out.
- Updated commands to match the current tutorial.
- Swap out nclprd for pythonprd.

Ran this script using 3 different hardware options (c5.4xlarge, c4.4xlarge, m5.2xlarge) for all 3 cases (sandy, derecho, snow) and tracked the AWS EC2 Runtimes [spreadsheet](https://docs.google.com/spreadsheets/d/1MRCZTlKq6DFYbnUz4t9poxW7q9dniRFA3wfNALqQ_xQ/edit#gid=0).
