### PR TITLE
Fix keyserver error in base images

### DIFF
--- a/components/base/Dockerfile
+++ b/components/base/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 
 USER root
 
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
+RUN gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
     && rm -r /root/.gnupg/ \

--- a/components/base/Dockerfile_simple
+++ b/components/base/Dockerfile_simple
@@ -4,7 +4,7 @@ MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 RUN groupadd comusers -g 9999
 RUN useradd -u 9999 -g comusers -G wheel -M -d /home comuser
 
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+RUN gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
The keyserver pool.sks-keyservers.net, which I had been using to verify the download of the "gosu" tool in the base images, is no longer active. So when trying to build the base image, this step fails. This is summarized in this issue:
 - https://github.com/docker-library/mysql/issues/263

This is mentioned in several places across the internet, including  https://www.reddit.com/r/crypto/comments/o7oh4w/skskeyserversnet_pool_dns_records_disabled/ . Even though this keyserver has been deprecated for a while, there's a lot of old stale documentation pointing to it, including that which I originally based by entrypoint script on.

The fix is simply to point to an active, more reliable keyserver,  hkps://keys.openpgp.org. This will fix the build issue, although it apparently remains to be seen what the future holds for key signing in this way. 

Still unsure if this is related to #46 or not....but hopefully when this is fixed we will see more reliable behavior?