### PR TITLE
Feature/issue 33 python_fhr

### DIFF
--- a/components/scripts/common/python/ALL_plot_allvars.py
+++ b/components/scripts/common/python/ALL_plot_allvars.py
@@ -12,8 +12,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -243,16 +243,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_10mW.py
+++ b/components/scripts/common/python/plot_10mW.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_2-5kmUH.py
+++ b/components/scripts/common/python/plot_2-5kmUH.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_250mbW.py
+++ b/components/scripts/common/python/plot_250mbW.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_2mT.py
+++ b/components/scripts/common/python/plot_2mT.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -221,16 +221,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_2mTd.py
+++ b/components/scripts/common/python/plot_2mTd.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -222,16 +222,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_500mbH_W_Vort.py
+++ b/components/scripts/common/python/plot_500mbH_W_Vort.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_CompRef.py
+++ b/components/scripts/common/python/plot_CompRef.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_QPF.py
+++ b/components/scripts/common/python/plot_QPF.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_sbCAPE_CIN.py
+++ b/components/scripts/common/python/plot_sbCAPE_CIN.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/python/plot_slp.py
+++ b/components/scripts/common/python/plot_slp.py
@@ -14,8 +14,8 @@
 #                       Five command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Forecast hour
-#                       3. EXPT_BASEDIR: Experiment base directory
-#                       4. CARTOPY_DIR:  Base directory of cartopy shapefiles
+#                       3. GRIB_FILE: Input GRIB file to be plotted
+#                       4. CARTOPY_DIR: Base directory of cartopy shapefiles
 #                          -Shapefiles cannot be directly downloaded to NOAA
 #                            machines from the internet, so shapefiles need to
 #                            be downloaded if geopolitical boundaries are
@@ -199,16 +199,18 @@ print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
 
-EXPT_BASEDIR = str(sys.argv[3])
+GRIB_FILE = str(sys.argv[3])
 CARTOPY_DIR = str(sys.argv[4])
 domain = str(sys.argv[5])
 
 # Specify plotting domains
 domains=[domain]
 
-for dom in domains:
-     # Define the location of the input file
-     data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
+# Open the input file, if it exists
+if os.path.exists(GRIB_FILE):
+    data1 = pygrib.open(GRIB_FILE)
+else:
+    sys.exit('Error - input file does not exist ('+GRIB_FILE+').  Exit!')
 
 # Get the lats and lons
 grids = [data1]

--- a/components/scripts/common/run_python.ksh
+++ b/components/scripts/common/run_python.ksh
@@ -53,12 +53,20 @@ cd $PYTHONPRD_DIR
 # Include case-specific settings
 . $CASE_DIR/set_env.ksh
 
-# Loop through the forecast hours
+# Loop through the 2-digit forecast hours
+typeset -Z2 fcst_time
 fcst_time=$fhr_beg
-while [ $fcst_time -le $fhr_end ] ; do
+while [ $fcst_time -le $fhr_end ]; do
 
-  for domain in ${domain_list}
-  do
+  for domain in ${domain_list}; do
+
+    # Get the filename to be plotted
+    cur_file="${POSTPRD_DIR}/wrfprs_${domain}.${fcst_time}"
+
+    # Skip files that do not exist
+    if [[ ! -e ${cur_file} ]]; then
+      continue
+    fi
 
     # Run Python script(s)
     # To run individual plots, uncomment the line below and comment out the ALL* line.
@@ -68,7 +76,7 @@ while [ $fcst_time -le $fhr_end ] ; do
     # The ALL_plot_allvars.py script plots all 10 plot types in one script,
     # reducing I/O and allowing for a shorter run time.
     for pythonscript in `ls -1 $SCRIPT_DIR/python/ALL_*.py`; do
-      python $pythonscript $init_time $fcst_time $POSTPRD_DIR $CARTOPY_DIR $domain
+      python $pythonscript $init_time $fcst_time $cur_file $CARTOPY_DIR $domain
     done
   done
 
@@ -81,14 +89,12 @@ done
 echo convert to animated gif
 
 # Trim images
-for file in `ls -1 *png`
-do
+for file in `ls -1 *png`; do
   convert $file -trim $file
 done
 
 # Generate animated gifs
-for domain in ${domain_list}
-do
+for domain in ${domain_list}; do
   convert -delay 100 10mwind_${domain}*.png 10mwind_${domain}.gif
   convert -delay 100 250wind_${domain}*.png 250wind_${domain}.gif
   convert -delay 100 2mdew_${domain}*.png 2mdew_${domain}.gif


### PR DESCRIPTION
Running the python step for the derecho case no longer results in Traceback error messages like this:
```
Traceback (most recent call last):
  File "/home/scripts/common/python/ALL_plot_allvars.py", line 255, in <module>
    data1 = pygrib.open(EXPT_BASEDIR+'/wrfprs_'+dom+'.'+fhour)
  File "pygrib/_pygrib.pyx", line 321, in pygrib._pygrib.open.__cinit__
OSError: [Errno could not open %s] /home/postprd/wrfprs_d02.00
```
The 2 changes are:
1. Update run_python.ksh to compute the wrfprs filename to be plotted. If it doesn't exist, do not call any python scripts.
2. Change the command line args for ALL_ploy_allvars.py to specify the GRIB file to be plotted instead of re-computing it a second time.

Please refer to the log files attached to the ncar/container-dtc-nwp#33 issue when reviewing this PR.