### PR TITLE
Update WPS, WRF, MET, and METviewer versions

### DIFF
--- a/components/base/Dockerfile
+++ b/components/base/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Michael Kavulich <kavulich@ucar.edu>
 
 USER root
 
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.2/gosu-amd64.asc" \
+RUN gpg --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.13/gosu-amd64.asc" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
     && rm -r /root/.gnupg/ \

--- a/components/met/MET/Dockerfile
+++ b/components/met/MET/Dockerfile
@@ -77,7 +77,7 @@ RUN umask 0002 \
     MET_PYTHON_CC='-I/usr/include/python3.6m' MET_PYTHON_LD='-lpython3.6m' > ${LOG_FILE} \
  && LOG_FILE=/comsoftware/met/met-${MET_GIT_NAME}/met/make_install.log \
  && echo "Compiling met-${MET_GIT_NAME} and writing log file ${LOG_FILE}" \
- && make install > ${LOG_FILE}
+ && make install > ${LOG_FILE} 
 # && LOG_FILE=/comsoftware/met/met-${MET_GIT_NAME}/met/make_test.log \
 # && echo "Testing met-${MET_GIT_NAME} and writing log file ${LOG_FILE}" \
 # && make test > ${LOG_FILE} 2>&1

--- a/components/met/MET/Dockerfile
+++ b/components/met/MET/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER John Halley Gotway <johnhg@ucar.edu>
 # This Dockerfile compiles MET from source during "docker build" step
 #
 
-ENV MET_GIT_NAME    v9.1.3
+ENV MET_GIT_NAME    v10.0.0
 ENV MET_GIT_URL     https://github.com/dtcenter/MET.git
 ENV MET_DEVELOPMENT true
 

--- a/components/metviewer/METviewer/Dockerfile
+++ b/components/metviewer/METviewer/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER Tatiana Burek <tatiana@ucar.edu>
 #
 # This Dockerfile checks out METviewer from GitHub and builds the specified branch or tag.
 #
-ENV METVIEWER_GIT_NAME v3.1.1
-ENV METCALCPY_GIT_NAME alpha1
-ENV METPLOTPY_GIT_NAME METplotpy-alpha2
+ENV METVIEWER_GIT_NAME v4.0.0
+ENV METCALCPY_GIT_NAME v1.0.0
+ENV METPLOTPY_GIT_NAME v1.0.0
 
 #
 # Constants

--- a/components/metviewer/docker-compose-AWS.yml
+++ b/components/metviewer/docker-compose-AWS.yml
@@ -12,7 +12,7 @@ db:
 
     # For AWS, map ports using "80:8080"
 metviewer:
-    image: dtcenter/nwp-container-metviewer:3.4
+    image: dtcenter/nwp-container-metviewer:3.5
     container_name: metviewer
     ports:
     - "80:8080"

--- a/components/metviewer/docker-compose.yml
+++ b/components/metviewer/docker-compose.yml
@@ -11,7 +11,7 @@ db:
     tty: true
 #
 metviewer:
-    image: dtcenter/nwp-container-metviewer:3.4
+    image: dtcenter/nwp-container-metviewer:3.5
     container_name: metviewer
     ports:
     - "8080:8080"

--- a/components/scripts/derecho_20120629/namelist.wps
+++ b/components/scripts/derecho_20120629/namelist.wps
@@ -24,7 +24,7 @@
  truelat2  =  40.60,
  stand_lon = -84.90,
  geog_data_path = '/data/WPS_GEOG/',
- opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.3/geogrid',
 /
 
 &ungrib
@@ -35,6 +35,6 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.3/metgrid',
 /
 

--- a/components/scripts/derecho_20120629/set_env.ksh
+++ b/components/scripts/derecho_20120629/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.1"
-export WRF_VERSION="4.1.3"
+export WPS_VERSION="4.3"
+export WRF_VERSION="4.3"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/sandy_20121027/namelist.wps
+++ b/components/scripts/sandy_20121027/namelist.wps
@@ -24,7 +24,7 @@
  truelat2  =  60.0,
  stand_lon = -73.0,
  geog_data_path = '/data/WPS_GEOG/',
- opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.3/geogrid',
 /
 
 &ungrib
@@ -35,5 +35,5 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.3/metgrid',
 /

--- a/components/scripts/sandy_20121027/set_env.ksh
+++ b/components/scripts/sandy_20121027/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.1"
-export WRF_VERSION="4.1.3"
+export WPS_VERSION="4.3"
+export WRF_VERSION="4.3"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/snow_20160123/namelist.wps
+++ b/components/scripts/snow_20160123/namelist.wps
@@ -24,7 +24,7 @@
  truelat2  =  39.0,
  stand_lon = -97.0,
  geog_data_path = '/data/WPS_GEOG/',
- opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.1/geogrid',
+ opt_geogrid_tbl_path = '/comsoftware/wrf/WPS-4.3/geogrid',
 /
 
 &ungrib
@@ -35,5 +35,5 @@
 &metgrid
  fg_name = 'FILE'
  io_form_metgrid = 2, 
- opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.1/metgrid',
+ opt_metgrid_tbl_path = '/comsoftware/wrf/WPS-4.3/metgrid',
 /

--- a/components/scripts/snow_20160123/set_env.ksh
+++ b/components/scripts/snow_20160123/set_env.ksh
@@ -2,8 +2,8 @@
 
 # WRF settings
 ########################################################################
-export WPS_VERSION="4.1"
-export WRF_VERSION="4.1.3"
+export WPS_VERSION="4.3"
+export WRF_VERSION="4.3"
 
 # GSI settings
 ########################################################################

--- a/components/wps_wrf/Dockerfile
+++ b/components/wps_wrf/Dockerfile
@@ -6,8 +6,8 @@ USER comuser
 RUN umask 0002 \
  && mkdir /comsoftware/wrf
 WORKDIR /comsoftware/wrf
-ENV WRF_VERSION 4.1.3
-ENV WPS_VERSION 4.1
+ENV WRF_VERSION 4.3
+ENV WPS_VERSION 4.3
 #
 # Download original sources
 #


### PR DESCRIPTION
This PR addresses [issue 45](https://github.com/NCAR/container-dtc-nwp/issues/45): updating WPS, WRF, MET, and METviewer versions.

WPS and WRF were updated to v4.3, MET was updated to v10.0.0., and METviewer was updated to v4.0.0.

Modifications were made to:
wps_wrf/Dockerfile
met/MET/Dockerfile
metviewer/METviewer/Dockerfile
metviewer/docker-compose-AWS.yml
metviewer/docker-compose.yml

scripts/derecho_20120629/set_env.ksh
scripts/derecho_20120629/namelist.wps
scripts/sandy_20121027/set_env.ksh
scripts/sandy_20121027/namelist.wps
scripts/snow_20160123/set_env.ksh
scripts/snow_20160123/namelist.wps

All images (wps_wrf, gsi, upp, python, nwp-container-met, nwp-containter-metviewer) were built successfully on AWS. All three cases were run end-to-end, and a sample of output was visually inspected.

NOTE: In metviewer/docker-compose-AWS.yml and metviewer/docker-compose.yml, the METviewer image is explicitly listed. It is listed as: dtcenter/nwp-container-metviewer:3.5 --> this does not yet exist on Dockerhub AND current tutorial instructions explicitly list 3.4. So this will technically not work/be correct until updates to 3.5 are made.
