### PR TITLE
Add casename

### DIFF
--- a/components/scripts/common/run_wps.ksh
+++ b/components/scripts/common/run_wps.ksh
@@ -62,7 +62,7 @@ else
 fi
 
 # Link input data. 
-$WRF_BUILD/WPS-${WPS_VERSION}/link_grib.csh $INPUT_DIR/model_data/gfs/*_*
+$WRF_BUILD/WPS-${WPS_VERSION}/link_grib.csh $INPUT_DIR/model_data/${case_name}/*
 
 ##################################
 #     Run the geogrid program    #

--- a/components/scripts/derecho_20120629/set_env.ksh
+++ b/components/scripts/derecho_20120629/set_env.ksh
@@ -5,6 +5,7 @@
 export WPS_VERSION="4.3"
 export WRF_VERSION="4.3"
 export input_data="GFS"
+export case_name="derecho"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/sandy_20121027/set_env.ksh
+++ b/components/scripts/sandy_20121027/set_env.ksh
@@ -5,6 +5,7 @@
 export WPS_VERSION="4.3"
 export WRF_VERSION="4.3"
 export input_data="GFS"
+export case_name="sandy"
 
 # GSI settings
 ########################################################################

--- a/components/scripts/snow_20160123/set_env.ksh
+++ b/components/scripts/snow_20160123/set_env.ksh
@@ -5,6 +5,7 @@
 export WPS_VERSION="4.3"
 export WRF_VERSION="4.3"
 export input_data="GFS"
+export case_name="snow"
 
 # GSI settings
 ########################################################################


### PR DESCRIPTION
This PR will fix #51 .

An extra environmental variable (case_name) was added to set_env.ksh of each case where user can indicate the case name, e.g. "sandy".
The common run_wps.ksh script was updated to removed the hard coded subdirectory "gfs" from the path pointing to the model input data.
Tests performed:
Sandy on MacOS with main branch wps_wrf image built locally. Successful through WPS/metgrid steps.

**Important!!** Upon merging of this PR, must move updated packaged model input data from staged area (data_temp) to live directory for download on Mohawk and Cheyenne.  Tarballs have been updated to reflect new paths.  Need to wait until #54 is merged first and ready for tagging/releasing of v3.5.