### PR TITLE
Changed to run_python.ksh to account for shapefiles moving under /data.

### DIFF
--- a/components/scripts/common/run_python.ksh
+++ b/components/scripts/common/run_python.ksh
@@ -13,7 +13,8 @@ SCRIPT_DIR="/home/scripts/common"
 CASE_DIR="/home/scripts/case"
 POSTPRD_DIR="/home/postprd"
 PYTHONPRD_DIR="/home/pythonprd"
-CARTOPY_DIR="$SCRIPT_DIR/python/shapefiles"
+DATA_DIR="/home/data"
+CARTOPY_DIR="$DATA_DIR"
 mkdir -p $CARTOPY_DIR
 
 # Check for the correct container


### PR DESCRIPTION
This PR fixes #56. A weblink that hosts shapefile data is currently non-responsive, so the Python plotting does not work unless the user already has the shapefiles downloaded. The proposed solution is to provide the shapefile data similar to how we provide WPS geog, CRTM, model initialization, and observation data. Modifications have been made to /scripts/common/run_python.ksh to account for the shapefiles being housed under /data (instead of /scripts/common/python/shapefiles).

This is only a minor change to the actual repo, but it will also result in needing to:

1) Change the Python run commands for each case (e.g., for Sandy) to account for mounting in the data:
docker run --rm -it -e LOCAL_USER_ID=`id -u $USER` \
-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/common:/home/scripts/common \
-v ${PROJ_DIR}/container-dtc-nwp/components/scripts/sandy_20121027:/home/scripts/case \
-v ${PROJ_DIR}/container-dtc-nwp/data/shapefiles:/home/data/shapefiles \
-v ${CASE_DIR}/postprd:/home/postprd -v ${CASE_DIR}/pythonprd:/home/pythonprd \
--name run-sandy-python dtcenter/python:3.5 /home/scripts/common/run_python.ksh

2) Update the static/initialization download instructions and provide the [tar file with necessary shapefiles](https://dtcenter.ucar.edu/dfiles/container_nwp_tutorial/tar_files/shapefiles.tar.gz).

I tested this with dtcenter/python:3.5 on my local Mac for the sandy case. As a note, depending on the order of operations of when issues are addressed and PRs are made, [issue 55](https://github.com/NCAR/container-dtc-nwp/issues/55) proposes moving the /data directory outside of container-dtc-nwp, which would affect the volume mounting in the example above.